### PR TITLE
Found a new bug on MSVC 64 :)

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -56,7 +56,7 @@ distribution.
 
 #if defined(DEBUG)
         #if defined(_MSC_VER)
-                #define TIXMLASSERT( x )           if ( !(x)) { _asm { int 3 } } //if ( !(x)) WinDebugBreak()
+                #define TIXMLASSERT( x )           if ( !(x)) { __debugbreak(); } //if ( !(x)) WinDebugBreak()
         #elif defined (ANDROID_NDK)
                 #include <android/log.h>
                 #define TIXMLASSERT( x )           if ( !(x)) { __android_log_assert( "assert", "grinliz", "ASSERT in '%s' at %d.", __FILE__, __LINE__ ); }


### PR DESCRIPTION
When building txml2 with the debug define it breaks since __asm  is not available in 64 bit mode. Replaced it with __debugbreak (http://msdn.microsoft.com/en-us/library/f408b4et(v=vs.110).aspx).

Cheers!
