### PR TITLE
Fixed compiler warnings

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -120,7 +120,7 @@ char* StrPair::ParseText( char* p, const char* endTag, int strFlags )
 
 	char* start = p;	// fixme: hides a member
 	char  endChar = *endTag;
-	int   length = strlen( endTag );	
+	size_t length = strlen( endTag );
 
 	// Inner loop of text parsing.
 	while ( *p ) {
@@ -316,7 +316,7 @@ const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
 	if ( *(p+1) == '#' && *(p+2) )
 	{
 		unsigned long ucs = 0;
-		int delta = 0;
+		ptrdiff_t delta = 0;
 		unsigned mult = 1;
 
 		if ( *(p+2) == 'x' )
@@ -329,7 +329,7 @@ const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
 
 			if ( !q || !*q ) return 0;
 
-			delta = (q-p);
+			delta = q-p;
 			--q;
 
 			while ( *q != 'x' )


### PR DESCRIPTION
Fixed VS2010 x64 compiler warnings about possible loss of data while saving the strlen result and pointer diff as an int.
