### PR TITLE
add a method to help get the size of the XML file in memory

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1371,6 +1371,10 @@ public:
 		the XML file in memory.
 	*/
 	const char* CStr() const { return buffer.Mem(); }
+	/**
+   		Return the size of the XML file in memory
+  	*/
+  	const int SizeOfCStr()const{ return buffer.Size(); }
 
 private:
 	void SealElement();


### PR DESCRIPTION
I think a method for get the size of the  XML file in memory is useful.
Sometimes When processing the memory of the XML file, we need the Size;
