### PR TITLE
Add compact mode to XMLPrint for printing without '\n' and space

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1501,13 +1501,14 @@ void XMLDocument::PrintError() const
 }
 
 
-XMLPrinter::XMLPrinter( FILE* file ) : 
+XMLPrinter::XMLPrinter( FILE* file, bool compact ) : 
 	elementJustOpened( false ), 
 	firstElement( true ),
 	fp( file ), 
 	depth( 0 ), 
 	textDepth( -1 ),
-	processEntities( true )
+	processEntities( true ),
+	compactMode( compact )
 {
 	for( int i=0; i<ENTITY_RANGE; ++i ) {
 		entityFlag[i] = false;
@@ -1627,7 +1628,7 @@ void XMLPrinter::OpenElement( const char* name )
 	}
 	stack.Push( name );
 
-	if ( textDepth < 0 && !firstElement ) {
+	if ( textDepth < 0 && !firstElement && !compactMode ) {
 		Print( "\n" );
 		PrintSpace( depth );
 	}
@@ -1689,7 +1690,7 @@ void XMLPrinter::CloseElement()
 		Print( "/>" );
 	}
 	else {
-		if ( textDepth < 0 ) {
+		if ( textDepth < 0 && !compactMode) {
 			Print( "\n" );
 			PrintSpace( depth );
 		}
@@ -1698,7 +1699,7 @@ void XMLPrinter::CloseElement()
 
 	if ( textDepth == depth )
 		textDepth = -1;
-	if ( depth == 0 )
+	if ( depth == 0 && !compactMode)
 		Print( "\n" );
 	elementJustOpened = false;
 }
@@ -1734,7 +1735,7 @@ void XMLPrinter::PushComment( const char* comment )
 	if ( elementJustOpened ) {
 		SealElement();
 	}
-	if ( textDepth < 0 && !firstElement ) {
+	if ( textDepth < 0 && !firstElement && !compactMode) {
 		Print( "\n" );
 		PrintSpace( depth );
 	}
@@ -1748,7 +1749,7 @@ void XMLPrinter::PushDeclaration( const char* value )
 	if ( elementJustOpened ) {
 		SealElement();
 	}
-	if ( textDepth < 0 && !firstElement) {
+	if ( textDepth < 0 && !firstElement && !compactMode) {
 		Print( "\n" );
 		PrintSpace( depth );
 	}
@@ -1762,7 +1763,7 @@ void XMLPrinter::PushUnknown( const char* value )
 	if ( elementJustOpened ) {
 		SealElement();
 	}
-	if ( textDepth < 0 && !firstElement ) {
+	if ( textDepth < 0 && !firstElement && !compactMode) {
 		Print( "\n" );
 		PrintSpace( depth );
 	}

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1329,7 +1329,7 @@ public:
 		this will print to the FILE. Else it will print
 		to memory, and the result is available in CStr()
 	*/
-	XMLPrinter( FILE* file=0 );
+	XMLPrinter( FILE* file=0, bool compact = false );
 	~XMLPrinter()	{}
 
 	/** If streaming, write the BOM and declaration. */
@@ -1378,6 +1378,14 @@ public:
   	*/
   	const int CStrSize()const{ return buffer.Size(); }
 
+	/**
+  	Set printer to compact mode, for printing without '\n' and space,
+		let output file smaller.
+	*/
+	void SetCompactMode( bool on ){ compactMode = on; }
+	bool IsCompactMode()const{ return compactMode; };
+  
+
 private:
 	void SealElement();
 	void PrintSpace( int depth );
@@ -1390,6 +1398,7 @@ private:
 	int depth;
 	int textDepth;
 	bool processEntities;
+	bool compactMode;
 
 	enum {
 		ENTITY_RANGE = 64,


### PR DESCRIPTION
let output file smaller.
usage:
//------------------------------------------------
XMLPrinter printer;
printer->SetCompactMode( true ); //enable compact mode
doc->Print( &printer );
SomeFunction( printer.CStr() );
//------------------------------------------------
or
//------------------------------------------------
//enable at construction
XMLPrinter printer( file, true );         // to file
//XMLPrinter printer( NULL, true ); // to men
doc->Print( &printer );
SomeFunction( printer.CStr() );
//------------------------------------------------

The '\n' and space in Text or Attribute will be kept.
