### PR TITLE
Add support to XMLDocument to save file in cimpact mode.

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1563,7 +1563,7 @@ int XMLDocument::LoadFile( FILE* fp )
 }
 
 
-int XMLDocument::SaveFile( const char* filename )
+int XMLDocument::SaveFile( const char* filename, bool compact )
 {
 #if defined(_MSC_VER)
 #pragma warning ( push )
@@ -1577,15 +1577,15 @@ int XMLDocument::SaveFile( const char* filename )
 		SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, filename, 0 );
 		return errorID;
 	}
-	SaveFile(fp);
+	SaveFile(fp, compact);
 	fclose( fp );
 	return errorID;
 }
 
 
-int XMLDocument::SaveFile( FILE* fp )
+int XMLDocument::SaveFile( FILE* fp, bool compact )
 {
-	XMLPrinter stream( fp );
+	XMLPrinter stream( fp, compact );
 	Print( &stream );
 	return errorID;
 }

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1075,7 +1075,7 @@ public:
 		Returns XML_NO_ERROR (0) on success, or
 		an errorID.
 	*/
-	int SaveFile( const char* filename );
+	int SaveFile( const char* filename, bool compact = false );
 
 	/**
 		Save the XML file to disk. You are responsible
@@ -1084,7 +1084,7 @@ public:
 		Returns XML_NO_ERROR (0) on success, or
 		an errorID.
 	*/
-	int SaveFile( FILE* );
+	int SaveFile( FILE* fp, bool compact = false );
 
 	bool ProcessEntities() const						{ return processEntities; }
 


### PR DESCRIPTION
Here is a patch that adds support for saving a document file in compact mode.
