### PR TITLE
just remove a compile warning :)

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1566,7 +1566,7 @@ int XMLDocument::LoadFile( FILE* fp )
 	InitDocument();
 
 	fseek( fp, 0, SEEK_END );
-	unsigned size = ftell( fp );
+	size_t size = ftell( fp );
 	fseek( fp, 0, SEEK_SET );
 
 	if ( size == 0 ) {


### PR DESCRIPTION
just remove a compile warning :)

```
1569: unsigned size = ftell( fp );
```

to

```
1569: size_t size = ftell( fp );
```
