### PR TITLE
Fix for BOM multiplication

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1668,12 +1668,6 @@ XMLError XMLDocument::Parse( const char* p, size_t len )
         SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
         return _errorID;
     }
-    if ( len == (size_t)(-1) ) {
-        len = strlen( p );
-    }
-    _charBuffer = new char[ len+1 ];
-    memcpy( _charBuffer, p, len );
-    _charBuffer[len] = 0;
 
     p = XMLUtil::SkipWhiteSpace( p );
     p = XMLUtil::ReadBOM( p, &_writeBOM );
@@ -1681,6 +1675,17 @@ XMLError XMLDocument::Parse( const char* p, size_t len )
         SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
         return _errorID;
     }
+
+    if ( len == (size_t)(-1) ) {
+        len = strlen( p );
+    }
+    else if (_writeBOM) {
+        len -= 3;
+    }
+
+    _charBuffer = new char[ len+1 ];
+    memcpy( _charBuffer, p, len );
+    _charBuffer[len] = 0;
 
     ParseDeep( _charBuffer, 0 );
     return _errorID;

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1016,6 +1016,17 @@ int main( int argc, const char ** argv )
 		XMLTest( "CStrSize", printer.CStrSize(), 42, false );
 	}
 	{
+		// BOM preservation
+		static const char* xml  = "\xef\xbb\xbf<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+		XMLDocument doc;
+		doc.Parse( xml );
+
+		XMLPrinter printer;
+		doc.Print( &printer );
+
+		XMLTest( "BOM preservation", printer.CStr(), xml, false );
+	}
+	{
 		const char* xml = "<ipxml ws='1'><info bla=' /></ipxml>";
 		XMLDocument doc;
 		doc.Parse( xml );


### PR DESCRIPTION
Quick fix preventing BOM++ on every parse-print pair
