### PR TITLE
Initialize pointers in constructor

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -581,7 +581,8 @@ XMLNode::XMLNode( XMLDocument* doc ) :
     _document( doc ),
     _parent( 0 ),
     _firstChild( 0 ), _lastChild( 0 ),
-    _prev( 0 ), _next( 0 )
+    _prev( 0 ), _next( 0 ),
+    _memPool( 0 )
 {
 }
 

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1069,7 +1069,7 @@ public:
 private:
     enum { BUF_SIZE = 200 };
 
-    XMLAttribute() : _next( 0 ) {}
+    XMLAttribute() : _next( 0 ), _memPool( 0 ) {}
     virtual ~XMLAttribute()	{}
 
     XMLAttribute( const XMLAttribute& );	// not supported


### PR DESCRIPTION
Even if there is no apparent problem with not doing it right now, it's cleaner and always a good idea to do so. And it makes static code analyzer happy. ;)
