### PR TITLE
Add a Code::Blocks project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,11 @@ Win32/
 x64/
 ipch/
 resources/out/
+tinyxml2/tinyxml2-cbp/bin/
+tinyxml2/tinyxml2-cbp/obj/
 *.sdf
 *.suo
 *.opensdf
 *.user
+*.depend
+*.layout

--- a/readme.md
+++ b/readme.md
@@ -262,8 +262,9 @@ And additionally a test file:
 * xmltest.cpp
 
 Simply compile and run. There is a visual studio 2010 project included, a simple Makefile, 
-an XCode project, and a cmake CMakeLists.txt included to help you. The top of tinyxml.h
-even has a simple g++ command line if you are are *nix and don't want to use a build system.
+an XCode project, a Code::Blocks project, and a cmake CMakeLists.txt included to help you. 
+The top of tinyxml.h even has a simple g++ command line if you are are *nix and don't want 
+to use a build system.
 
 Documentation
 -------------

--- a/tinyxml2/tinyxml2-cbp/README
+++ b/tinyxml2/tinyxml2-cbp/README
@@ -1,0 +1,3 @@
+The (default) Release configuration of this project builds a ready to use static library.
+The Debug configuration of this project builds an executable console application that 
+executes all tests provided for tinyxml2 in the xmltest.cpp file.

--- a/tinyxml2/tinyxml2-cbp/tinyxml2-cbp.cbp
+++ b/tinyxml2/tinyxml2-cbp/tinyxml2-cbp.cbp
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<CodeBlocks_project_file>
+	<FileVersion major="1" minor="6" />
+	<Project>
+		<Option title="tinyxml2-cbp" />
+		<Option execution_dir="../" />
+		<Option pch_mode="2" />
+		<Option compiler="gcc" />
+		<Build>
+			<Target title="Release">
+				<Option output="bin/Release/tinyxml2" prefix_auto="1" extension_auto="1" />
+				<Option working_dir="" />
+				<Option object_output="obj/Release/" />
+				<Option type="2" />
+				<Option compiler="gcc" />
+				<Compiler>
+					<Add option="-O2" />
+				</Compiler>
+				<Linker>
+					<Add option="-s" />
+				</Linker>
+			</Target>
+			<Target title="Debug">
+				<Option output="bin/Debug/tinyxml2-cbp" prefix_auto="1" extension_auto="1" />
+				<Option working_dir="../../" />
+				<Option object_output="obj/Debug/" />
+				<Option type="1" />
+				<Option compiler="gcc" />
+				<Compiler>
+					<Add option="-g" />
+				</Compiler>
+			</Target>
+		</Build>
+		<Compiler>
+			<Add option="-Wall" />
+		</Compiler>
+		<Unit filename="../../tinyxml2.cpp" />
+		<Unit filename="../../tinyxml2.h" />
+		<Unit filename="../../xmltest.cpp">
+			<Option target="Debug" />
+		</Unit>
+		<Extensions>
+			<code_completion />
+			<envvars />
+			<debugger />
+			<lib_finder disable_auto="1" />
+		</Extensions>
+	</Project>
+</CodeBlocks_project_file>


### PR DESCRIPTION
This adds a Code::Blocks project which can make life easier to people under Windows who don't have Visual Studio and who want to build tinyxml2.
