### PR TITLE
Added depth as constructor argument to XMLPrinter

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1729,11 +1729,11 @@ void XMLDocument::PrintError() const
 }
 
 
-XMLPrinter::XMLPrinter( FILE* file, bool compact ) :
+XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
     _elementJustOpened( false ),
     _firstElement( true ),
     _fp( file ),
-    _depth( 0 ),
+    _depth( depth ),
     _textDepth( -1 ),
     _processEntities( true ),
     _compactMode( compact )
@@ -1840,7 +1840,7 @@ void XMLPrinter::PrintString( const char* p, bool restricted )
 void XMLPrinter::PushHeader( bool writeBOM, bool writeDec )
 {
     if ( writeBOM ) {
-		static const unsigned char bom[] = { TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1, TIXML_UTF_LEAD_2, 0 };
+        static const unsigned char bom[] = { TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1, TIXML_UTF_LEAD_2, 0 };
         Print( "%s", bom );
     }
     if ( writeDec ) {
@@ -1858,6 +1858,8 @@ void XMLPrinter::OpenElement( const char* name )
 
     if ( _textDepth < 0 && !_firstElement && !_compactMode ) {
         Print( "\n" );
+    }
+    if ( !_compactMode ) {
         PrintSpace( _depth );
     }
 

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -125,11 +125,9 @@ class XMLDocument;
 class XMLElement;
 class XMLAttribute;
 class XMLComment;
-class XMLNode;
 class XMLText;
 class XMLDeclaration;
 class XMLUnknown;
-
 class XMLPrinter;
 
 /*
@@ -1884,7 +1882,7 @@ public:
     	If 'compact' is set to true, then output is created
     	with only required whitespace and newlines.
     */
-    XMLPrinter( FILE* file=0, bool compact = false );
+    XMLPrinter( FILE* file=0, bool compact = false, int depth = 0 );
     ~XMLPrinter()	{}
 
     /** If streaming, write the BOM and declaration. */


### PR DESCRIPTION
Added depth as constructor argument to XMLPrinter. This way, XML files that are not written with XMLDocument can be properly indented.

Removed unused forward declaration
