### PR TITLE
Issue #134

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -595,6 +595,10 @@ XMLNode::~XMLNode()
     }
 }
 
+const char* XMLNode::Value() const 
+{
+    return _value.GetStr();
+}
 
 void XMLNode::SetValue( const char* str, bool staticMem )
 {
@@ -1040,6 +1044,17 @@ bool XMLUnknown::Accept( XMLVisitor* visitor ) const
 }
 
 // --------- XMLAttribute ---------- //
+
+const char* XMLAttribute::Name() const 
+{
+    return _name.GetStr();
+}
+
+const char* XMLAttribute::Value() const 
+{
+    return _value.GetStr();
+}
+
 char* XMLAttribute::ParseDeep( char* p, bool processEntities )
 {
     // Parse using the name rules: bug fix, was using ParseText before

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -643,9 +643,7 @@ public:
     	Text:		the text string
     	@endverbatim
     */
-    const char* Value() const			{
-        return _value.GetStr();
-    }
+    const char* Value() const;
 
     /** Set the Value of an XML node.
     	@sa Value()
@@ -1014,13 +1012,11 @@ class TINYXML2_LIB XMLAttribute
     friend class XMLElement;
 public:
     /// The name of the attribute.
-    const char* Name() const {
-        return _name.GetStr();
-    }
+    const char* Name() const;
+
     /// The value of the attribute.
-    const char* Value() const {
-        return _value.GetStr();
-    }
+    const char* Value() const;
+
     /// The next attribute in the list.
     const XMLAttribute* Next() const {
         return _next;


### PR DESCRIPTION
Change 3 methods to not being inlined. They reference the StrPair class, which is not exported, thus creating linker problems with tinyxml2 in a DLL.

This is my first pull request. Please let me know if this works for you.
