### PR TITLE
you have to check len before accsessing "p".

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1702,6 +1702,11 @@ XMLError XMLDocument::Parse( const char* p, size_t len )
 	const char* start = p;
     Clear();
 
+    if ( len == 0 ) {
+        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
+        return _errorID;
+    }
+
     if ( !p || !*p ) {
         SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
         return _errorID;


### PR DESCRIPTION
In "Parse" function, "p" pointer is accessed before checking len parameter.
So, if we call doc->Parse(new byte [0], 0), tinyxml would crash due to segmentation fault.
