### PR TITLE
Fixed issue 147 (XMLDocument::LoadFile() may crash on non-regular file)

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1639,6 +1639,13 @@ XMLError XMLDocument::LoadFile( FILE* fp )
 {
     Clear();
 
+    fseek( fp, 0, SEEK_SET );
+    fgetc( fp );
+    if ( ferror( fp ) != 0 ) {
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+
     fseek( fp, 0, SEEK_END );
     size_t size = ftell( fp );
     fseek( fp, 0, SEEK_SET );


### PR DESCRIPTION
Fixing crash. The crash occured because the indicated file size was ~0 that resulted in a allocation failure. The fix doesn't check the file size though, but instead makes sure that the file can be read without errors.
