### PR TITLE
Fix compilation issue under Cygwin

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -33,6 +33,9 @@ distribution.
 #   include <string.h>
 #   include <stdarg.h>
 #else
+#if defined(__CYGWIN__)
+#undef __STRICT_ANSI__
+#endif
 #   include <cctype>
 #   include <climits>
 #   include <cstdio>


### PR DESCRIPTION
As requested, this pull request is to accommodate the change to allow for tinyxml2 to compile under Cygwin. 
