### PR TITLE
Fixed _CRT_SECURE_NO_WARNINGS macro redefinition warning

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1,5 +1,7 @@
 #if defined( _MSC_VER )
-	#define _CRT_SECURE_NO_WARNINGS		// This test file is not intended to be secure.
+	#if !defined( _CRT_SECURE_NO_WARNINGS )
+		#define _CRT_SECURE_NO_WARNINGS		// This test file is not intended to be secure.
+	#endif
 #endif
 
 #include "tinyxml2.h"


### PR DESCRIPTION
Fixed the compilation warning under MSVC environment due to _CRT_SECURE_NO_WARNINGS macro redefinition in xmltest.cpp (first defined as flag in CMakeLists.txt). This issue is critical for "warnings are errors" configurations.
