### PR TITLE
Fix compiler warning: extra ';' after member function definition

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2031,7 +2031,7 @@ public:
     }
 
 protected:
-	virtual bool CompactMode( const XMLElement& )	{ return _compactMode; };
+	virtual bool CompactMode( const XMLElement& )	{ return _compactMode; }
 
 	/** Prints out the space before an element. You may override to change
 	    the space and tabs used. A PrintSpace() override should call Print().


### PR DESCRIPTION
See Issue #185
