### PR TITLE
Replace C-style cast with static_cast

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -370,7 +370,7 @@ public:
             return;
         }
         --_currentAllocs;
-        Chunk* chunk = (Chunk*)mem;
+        Chunk* chunk = static_cast<Chunk*>( mem );
 #ifdef DEBUG
         memset( chunk, 0xfe, sizeof(Chunk) );
 #endif


### PR DESCRIPTION
This was a style warning from Cppcheck. Nothing serious, but the fix is trivial.
