### PR TITLE
Fixed DOCTYPE parsing to include internal DTD

### DIFF
--- a/resources/dictionary.xml
+++ b/resources/dictionary.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE Dictionary [
+  <!-- Test of the ability to parse internally defined DTD -->
+  <!ELEMENT Dictionary    (Storage+)             >
+  <!ELEMENT Storage       (WordFile+, WordList?) >
+  <!ELEMENT Growth         EMPTY                 >
+  <!ELEMENT WordFile      (Growth?)              >
+  <!ELEMENT WordList      (Initialization?)      >
+  <!ELEMENT Initialization EMPTY                 >
+
+  <!ATTLIST Storage         name     CDATA                  #REQUIRED
+                            life     (permanent|temporary)  "permanent"
+                            tested   (true|false)           "true">
+
+  <!ATTLIST WordFile        name     CDATA                  #REQUIRED
+                            size     CDATA                  "500M"
+                            recyled  (true|false)           "true"
+                            tracking (on|off)               "off">
+
+  <!ATTLIST Growth          next     CDATA                  "500M"
+                            max      CDATA                  "unlimited">
+
+  <!ATTLIST WordList        method   (local|dictionary)     "local">
+
+  <!ATTLIST Initialization  method   (dynamic|static)       "dynamic"
+                            size     CDATA                  "1M" >
+
+]>
+
+<Dictionary>
+
+  <Storage name="APP_DATA" life="permanent" tested="true">
+    <WordFile name="/data15/local/task_list01.dict" size="250M" recyled="true" tracking="off">
+    </WordFile>
+    <WordFile name="/data15/local/task_list02.dict" size="250M" recyled="true" tracking="on">
+      <Growth next="500M" max="unlimited"/>
+    </WordFile>
+    <WordList method="local">
+      <Initialization method="dynamic"/>
+    </WordList>
+  </Storage>
+
+
+  <Storage name="APP_INDEX" life="permanent" tested="true">
+    <WordFile name="/data20/local/site_list01.dict" size="250M" recyled="true" tracking="off">
+    </WordFile>
+    <WordFile name="/data20/local/site_list02.dict" size="250M" recyled="true" tracking="on">
+      <Growth next="500M" max="unlimited"/>
+    </WordFile>
+    <WordList method="local">
+      <Initialization method="dynamic"/>
+    </WordList>
+  </Storage>
+
+
+  <Storage name="APP_TEMP" life="temporary" tested="false">
+    <WordFile name="/data23/local/user_words01.dict" size="500M" recyled="true" tracking="on">
+      <Growth next="500M" max="unlimited"/>
+    </WordFile>
+    <WordList method="local">
+      <Initialization method="static" size="1M"/>
+    </WordList>
+  </Storage>
+
+</Dictionary>

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -135,6 +135,7 @@ class XMLComment;
 class XMLText;
 class XMLDeclaration;
 class XMLUnknown;
+class XMLDtd;
 class XMLPrinter;
 
 /*
@@ -474,6 +475,10 @@ public:
     virtual bool Visit( const XMLComment& /*comment*/ )				{
         return true;
     }
+    /// Visit a DTD node.
+    virtual bool Visit( const XMLDtd& /*unknown*/ )				{
+        return true;
+    }
     /// Visit an unknown node.
     virtual bool Visit( const XMLUnknown& /*unknown*/ )				{
         return true;
@@ -647,6 +652,11 @@ public:
     virtual XMLDeclaration*	ToDeclaration()	{
         return 0;
     }
+    /// Safely cast to an DTD, or null.
+    virtual XMLDtd*		ToDtd()		{
+        return 0;
+    }
+
     /// Safely cast to an Unknown, or null.
     virtual XMLUnknown*		ToUnknown()		{
         return 0;
@@ -667,6 +677,10 @@ public:
     virtual const XMLDeclaration*	ToDeclaration() const	{
         return 0;
     }
+    virtual const XMLDtd*		ToDtd() const		{
+        return 0;
+    }
+
     virtual const XMLUnknown*		ToUnknown() const		{
         return 0;
     }
@@ -992,12 +1006,41 @@ protected:
 };
 
 
+/** The <!DOCTYPE> structure can contain internal definition that
+  may contains other <!xxx ...> entities.  (Otherwise, these could
+  be handled as XMLUnknown nodes.) 
+	It will be written back to the XML, unchanged, when the file
+	is saved.
+*/
+
+class TINYXML2_LIB XMLDtd : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual XMLDtd*	ToDtd()					{
+        return this;
+    }
+    virtual const XMLDtd* ToDtd() const		{
+        return this;
+    }
+
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    char* ParseDeep( char*, StrPair* endTag );
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+protected:
+    XMLDtd( XMLDocument* doc );
+    virtual ~XMLDtd();
+    XMLDtd( const XMLDtd& );	// not supported
+    XMLDtd& operator=( const XMLDtd& );	// not supported
+};
+
 /** Any tag that TinyXML-2 doesn't recognize is saved as an
 	unknown. It is a tag of text, but should not be modified.
 	It will be written back to the XML, unchanged, when the file
 	is saved.
-
-	DTD tags get thrown into XMLUnknowns.
 */
 class TINYXML2_LIB XMLUnknown : public XMLNode
 {
@@ -1639,6 +1682,13 @@ public:
     */
     XMLDeclaration* NewDeclaration( const char* text=0 );
     /**
+    	Create a new DTD associated with
+    	this Document. The memory for the object
+    	is managed by the Document.
+    */
+    XMLDtd* NewDtd( const char* text );
+
+    /**
     	Create a new Unknown associated with
     	this Document. The memory for the object
     	is managed by the Document.
@@ -1831,6 +1881,10 @@ public:
     XMLText* ToText() 							{
         return ( ( _node == 0 ) ? 0 : _node->ToText() );
     }
+    /// Safe cast to XMLDtd. This can return null.
+    XMLDtd* ToDtd() 					{
+        return ( ( _node == 0 ) ? 0 : _node->ToDtd() );
+    }
     /// Safe cast to XMLUnknown. This can return null.
     XMLUnknown* ToUnknown() 					{
         return ( ( _node == 0 ) ? 0 : _node->ToUnknown() );
@@ -1901,6 +1955,9 @@ public:
     }
     const XMLText* ToText() const				{
         return ( ( _node == 0 ) ? 0 : _node->ToText() );
+    }
+    const XMLDtd* ToDtd() const			{
+        return ( ( _node == 0 ) ? 0 : _node->ToDtd() );
     }
     const XMLUnknown* ToUnknown() const			{
         return ( ( _node == 0 ) ? 0 : _node->ToUnknown() );
@@ -2013,6 +2070,7 @@ public:
     virtual bool Visit( const XMLText& text );
     virtual bool Visit( const XMLComment& comment );
     virtual bool Visit( const XMLDeclaration& declaration );
+    virtual bool Visit( const XMLDtd& dtd);
     virtual bool Visit( const XMLUnknown& unknown );
 
     /**

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -90,10 +90,11 @@ void NullLineEndings( char* p )
 }
 
 
-int example_1()
+int example_1(const char *xml_file)
 {
 	XMLDocument doc;
-	doc.LoadFile( "resources/dream.xml" );
+
+	doc.LoadFile( xml_file );
 
 	return doc.ErrorID();
 }
@@ -324,7 +325,8 @@ int main( int argc, const char ** argv )
 	}
 	fclose( fp );
 
-	XMLTest( "Example-1", 0, example_1() );
+	XMLTest( "Example-1", 0, example_1("resources/dream.xml") );
+	XMLTest( "Example-1", 0, example_1("resources/dictionary.xml") );
 	XMLTest( "Example-2", 0, example_2() );
 	XMLTest( "Example-3", 0, example_3() );
 	XMLTest( "Example-4", true, example_4() );
@@ -455,9 +457,9 @@ int main( int argc, const char ** argv )
 
 		XMLTest( "Dream", "xml version=\"1.0\"",
 						  doc.FirstChild()->ToDeclaration()->Value() );
-		XMLTest( "Dream", true, doc.FirstChild()->NextSibling()->ToUnknown() ? true : false );
+		XMLTest( "Dream", true, doc.FirstChild()->NextSibling()->ToDtd() ? true : false );
 		XMLTest( "Dream", "DOCTYPE PLAY SYSTEM \"play.dtd\"",
-						  doc.FirstChild()->NextSibling()->ToUnknown()->Value() );
+						  doc.FirstChild()->NextSibling()->ToDtd()->Value() );
 		XMLTest( "Dream", "And Robin shall restore amends.",
 						  doc.LastChild()->LastChild()->LastChild()->LastChild()->LastChildElement()->GetText() );
 		XMLTest( "Dream", "And Robin shall restore amends.",
@@ -467,13 +469,35 @@ int main( int argc, const char ** argv )
 		doc2.LoadFile( "resources/out/dreamout.xml" );
 		XMLTest( "Dream-out", "xml version=\"1.0\"",
 						  doc2.FirstChild()->ToDeclaration()->Value() );
-		XMLTest( "Dream-out", true, doc2.FirstChild()->NextSibling()->ToUnknown() ? true : false );
+		XMLTest( "Dream-out", true, doc2.FirstChild()->NextSibling()->ToDtd() ? true : false );
 		XMLTest( "Dream-out", "DOCTYPE PLAY SYSTEM \"play.dtd\"",
-						  doc2.FirstChild()->NextSibling()->ToUnknown()->Value() );
+						  doc2.FirstChild()->NextSibling()->ToDtd()->Value() );
 		XMLTest( "Dream-out", "And Robin shall restore amends.",
 						  doc2.LastChild()->LastChild()->LastChild()->LastChild()->LastChildElement()->GetText() );
 
 		//gNewTotal = gNew - newStart;
+	}
+	{
+		// Test: Dictionary
+		XMLDocument doc;
+		doc.LoadFile( "resources/dictionary.xml" );
+
+		doc.SaveFile( "resources/out/dictionaryout.xml" );
+		doc.PrintError();
+
+		XMLTest( "Dictionary", "xml version=\"1.0\" encoding=\"UTF-8\"",
+						  doc.FirstChild()->ToDeclaration()->Value() );
+		XMLTest( "Dictionary", true, doc.FirstChild()->NextSibling()->ToDtd() ? true : false );
+    XMLTest( "Dictionary", "500M",
+             doc.LastChild()->LastChild()->FirstChild()->ToElement()->Attribute("size") );
+
+		XMLDocument doc2;
+		doc2.LoadFile( "resources/out/dictionaryout.xml" );
+		XMLTest( "Dictionary-out", "xml version=\"1.0\" encoding=\"UTF-8\"",
+						  doc2.FirstChild()->ToDeclaration()->Value() );
+		XMLTest( "Dictionary-out", true, doc2.FirstChild()->NextSibling()->ToDtd() ? true : false );
+    XMLTest( "Dictionary", "500M",
+             doc2.LastChild()->LastChild()->FirstChild()->ToElement()->Attribute("size") );
 	}
 
 
@@ -822,7 +846,7 @@ int main( int argc, const char ** argv )
 		doc.LoadFile( "resources/out/test7.xml" );
 		doc.Print();
 
-		const XMLUnknown* decl = doc.FirstChild()->NextSibling()->ToUnknown();
+		const XMLDtd* decl = doc.FirstChild()->NextSibling()->ToDtd();
 		XMLTest( "Correct value of unknown.", "DOCTYPE PLAY SYSTEM 'play.dtd'", decl->Value() );
 
 	}


### PR DESCRIPTION
The current XMLUnknown class cannot handle <!DOCTYPE ... > parsing when the DTD is provided internal to the XML document  ( i.e. contains <!ELEMENT>, <!ATTRIBUTE>, or <!ENTITY> elements ).    This is because the XMLUnknown endString is set to ">".

Rather than modifying the XMLUnknown class, I added a new XMLDtd class which handles the <!DOCTYPE> element correctly.   I was not sure if there was some other use for XMLUnknown and thus didn't want to mess with its inner workings.

The new XMLDtd class is based on the XMLUnknown class.  The only difference is the deepParse method.  In XMLDtd, it looks for the presence of an opening square bracket ( '[' ).  If found, it must find the matching closing bracket before finding endString ( '>' ).