### PR TITLE
Function signature is most likely wrong

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -561,8 +561,8 @@ public:
         return false;
     }
     
-    inline static int IsUTF8Continuation( const char p ) {
-        return p & 0x80;
+    inline static bool IsUTF8Continuation( const char p ) {
+        return ( p & 0x80 ) != 0;
     }
 
     static const char* ReadBOM( const char* p, bool* hasBOM );


### PR DESCRIPTION
I'm not _completely_ sure but it looks like the function signature is wrong and so is its implementation which helps write subtle bugs.
