### PR TITLE
Enable dump of debug heap memory leaks

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -279,6 +279,8 @@ int main( int argc, const char ** argv )
 {
 	#if defined( _MSC_VER ) && defined( DEBUG )
 		_CrtMemCheckpoint( &startMemState );
+		// Enable MS Visual C++ debug heap memory leaks dump on exit
+		_CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) | _CRTDBG_LEAK_CHECK_DF);
 	#endif
 
 	#if defined(_MSC_VER) || defined(MINGW32) || defined(__MINGW32__)


### PR DESCRIPTION
This definitely won't hurt and maybe helps identify memory leaks
