### PR TITLE
Rename test, fixed cmake warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,10 @@ set_target_properties(tinyxml2 PROPERTIES
 	VERSION "${GENERIC_LIB_VERSION}"
 	SOVERSION "${GENERIC_LIB_SOVERSION}")
 
-add_executable(test xmltest.cpp)
-add_dependencies(test tinyxml2)
-add_dependencies(test ${TARGET_DATA_COPY})
-target_link_libraries(test tinyxml2)
+add_executable(xmltest xmltest.cpp)
+add_dependencies(xmltest tinyxml2)
+add_dependencies(xmltest ${TARGET_DATA_COPY})
+target_link_libraries(xmltest tinyxml2)
 
 
 if(BUILD_STATIC_LIBS)
@@ -85,4 +85,4 @@ endforeach()
 configure_file(tinyxml2.pc.in tinyxml2.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
-#add_test(test ${SAMPLE_NAME} COMMAND $<TARGET_FILE:${SAMPLE_NAME}>)
+#add_test(xmltest ${SAMPLE_NAME} COMMAND $<TARGET_FILE:${SAMPLE_NAME}>)


### PR DESCRIPTION
CMake Warning (dev) at CMakeLists.txt:60 (add_executable):
  Policy CMP0037 is not set: Target names should not be reserved and should
  match a validity pattern.  Run "cmake --help-policy CMP0037" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  The target name "test" is reserved or not valid for certain CMake features,
  such as generator expressions, and may result in undefined behavior.
This warning is for project developers.  Use -Wno-dev to suppress it.
