### PR TITLE
Error checking never actually checked anything

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1654,6 +1654,9 @@ void XMLDocument::Clear()
 {
     DeleteChildren();
 
+#ifdef DEBUG
+    const bool hadError = Error();
+#endif
     _errorID = XML_NO_ERROR;
     _errorStr1 = 0;
     _errorStr2 = 0;
@@ -1669,7 +1672,7 @@ void XMLDocument::Clear()
 #endif
     
 #ifdef DEBUG
-    if ( Error() == false ) {
+    if ( !hadError ) {
         TIXMLASSERT( _elementPool.CurrentAllocs()   == _elementPool.Untracked() );
         TIXMLASSERT( _attributePool.CurrentAllocs() == _attributePool.Untracked() );
         TIXMLASSERT( _textPool.CurrentAllocs()      == _textPool.Untracked() );


### PR DESCRIPTION
This likely causes https://github.com/leethomason/tinyxml2/issues/233

Look at what `XMLDocument::Clear()` does. It first sets  `_errorID = XML_NO_ERROR;` and then later calls `Error()` which compares `_errorID` against `XML_NO_ERROR`. So `Error()` always returns _false_ at that point and the check doesn't really check anything and the _if_ inner code is being run at all times.
