### PR TITLE
Simplify node logic

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -855,7 +855,6 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEnd )
         p = node->ParseDeep( p, &endTag );
         if ( !p ) {
             DeleteNode( node );
-            node = 0;
             if ( !_document->Error() ) {
                 _document->SetError( XML_ERROR_PARSING, 0, 0 );
             }
@@ -890,16 +889,11 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEnd )
             }
             if ( mismatch ) {
                 _document->SetError( XML_ERROR_MISMATCHED_ELEMENT, node->Value(), 0 );
-                p = 0;
+                DeleteNode( node );
+                break;
             }
         }
-        if ( p == 0 ) {
-            DeleteNode( node );
-            node = 0;
-        }
-        if ( node ) {
-            this->InsertEndChild( node );
-        }
+        InsertEndChild( node );
     }
     return 0;
 }


### PR DESCRIPTION
The only effect of setting p to 0 here is to break the loop, using break is much simpler.
As for line 858, there is no point to set node to 0 and then break the loop right after.
