### PR TITLE
Unify character casts, reorganize checks

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1962,16 +1962,13 @@ XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
         _restrictedEntityFlag[i] = false;
     }
     for( int i=0; i<NUM_ENTITIES; ++i ) {
-        TIXMLASSERT( entities[i].value < ENTITY_RANGE );
-        if ( entities[i].value < ENTITY_RANGE ) {
-            _entityFlag[ (int)entities[i].value ] = true;
-        }
+        const char entityValue = entities[i].value;
+        TIXMLASSERT( 0 <= entityValue && entityValue < ENTITY_RANGE );
+        _entityFlag[ (unsigned char)entityValue ] = true;
     }
-    // Clang doesn't like indexing arrays with 'char'
-    // so cast to int. (Looks strange.)
-    _restrictedEntityFlag[(int)'&'] = true;
-    _restrictedEntityFlag[(int)'<'] = true;
-    _restrictedEntityFlag[(int)'>'] = true;	// not required, but consistency is nice
+    _restrictedEntityFlag[(unsigned char)'&'] = true;
+    _restrictedEntityFlag[(unsigned char)'<'] = true;
+    _restrictedEntityFlag[(unsigned char)'>'] = true;	// not required, but consistency is nice
     _buffer.Push( 0 );
 }
 
@@ -2039,7 +2036,7 @@ void XMLPrinter::PrintString( const char* p, bool restricted )
                 // Check for entities. If one is found, flush
                 // the stream up until the entity, write the
                 // entity, and keep looking.
-                if ( flag[(unsigned)(*q)] ) {
+                if ( flag[(unsigned char)(*q)] ) {
                     while ( p < q ) {
                         Print( "%c", *p );
                         ++p;

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1398,6 +1398,10 @@ int main( int argc, const char ** argv )
         doc.DeleteNode(pRoot);
     }
 
+	{
+		// Should not assert in DEBUG
+		XMLPrinter printer;
+	}
 
 	// ----------- Performance tracking --------------
 	{


### PR DESCRIPTION
Silencing clang warning by casting to int is hardly an example of the most readable code. This uses casts to `unsigned char` which make comments redundant.

Also there's no point in checking the range all the time when this can be done in a test (entities set doesn't change between runs).
