### PR TITLE
strchr() can only find what is was asked for

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -353,6 +353,7 @@ const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
         unsigned long ucs = 0;
         ptrdiff_t delta = 0;
         unsigned mult = 1;
+        const char semicolon = ';';
 
         if ( *(p+2) == 'x' ) {
             // Hexadecimal.
@@ -361,11 +362,12 @@ const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
             }
 
             const char* q = p+3;
-            q = strchr( q, ';' );
+            q = strchr( q, semicolon );
 
-            if ( !q || !*q ) {
+            if ( !q ) {
                 return 0;
             }
+            TIXMLASSERT( *q == semicolon );
 
             delta = q-p;
             --q;
@@ -394,11 +396,12 @@ const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
             }
 
             const char* q = p+2;
-            q = strchr( q, ';' );
+            q = strchr( q, semicolon );
 
-            if ( !q || !*q ) {
+            if ( !q ) {
                 return 0;
             }
+            TIXMLASSERT( *q == semicolon );
 
             delta = q-p;
             --q;


### PR DESCRIPTION
`strchr()` cannot possibly find null character if it was asked to find a semicolon.