### PR TITLE
Removing Visual Studio 2013 warnings

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -678,8 +678,10 @@ void XMLNode::DeleteChild( XMLNode* node )
 XMLNode* XMLNode::InsertEndChild( XMLNode* addThis )
 {
     TIXMLASSERT( addThis );
-    if ( addThis->_document != _document ) {
-        TIXMLASSERT( false );
+	
+	bool isOtherDocument = ( addThis->_document != _document );
+	if (isOtherDocument) {
+		TIXMLASSERT( !isOtherDocument ); //assure it fails if it is a different document
         return 0;
     }
     InsertChildPreamble( addThis );
@@ -708,8 +710,10 @@ XMLNode* XMLNode::InsertEndChild( XMLNode* addThis )
 XMLNode* XMLNode::InsertFirstChild( XMLNode* addThis )
 {
     TIXMLASSERT( addThis );
-    if ( addThis->_document != _document ) {
-        TIXMLASSERT( false );
+
+	bool isOtherDocument = (addThis->_document != _document);
+	if (isOtherDocument) {
+		TIXMLASSERT(!isOtherDocument); //assure it fails if it is a different document
         return 0;
     }
     InsertChildPreamble( addThis );
@@ -739,15 +743,17 @@ XMLNode* XMLNode::InsertFirstChild( XMLNode* addThis )
 XMLNode* XMLNode::InsertAfterChild( XMLNode* afterThis, XMLNode* addThis )
 {
     TIXMLASSERT( addThis );
-    if ( addThis->_document != _document ) {
-        TIXMLASSERT( false );
+	bool isOtherDocument = ( addThis->_document != _document );
+	if (isOtherDocument) {
+		TIXMLASSERT(!isOtherDocument); //assure it fails if it is a different document
         return 0;
     }
 
     TIXMLASSERT( afterThis );
 
-    if ( afterThis->_parent != this ) {
-        TIXMLASSERT( false );
+	isOtherDocument = ( afterThis->_parent != this );
+	if (isOtherDocument) {
+		TIXMLASSERT(!isOtherDocument); //assure it fails here as well
         return 0;
     }
 


### PR DESCRIPTION
It happens when integrated with cppcheck:
1>..\externals\tinyxml\tinyxml2.cpp(674): warning C4127: conditional
expression is constant
1>..\externals\tinyxml\tinyxml2.cpp(708): warning C4127: conditional
expression is constant
1>..\externals\tinyxml\tinyxml2.cpp(743): warning C4127: conditional
expression is constant
1>..\externals\tinyxml\tinyxml2.cpp(750): warning C4127: conditional
expression is constant