### PR TITLE
Resolve crash when printing malformed entities - issue 291

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -228,11 +228,19 @@ const char* StrPair::GetStr()
                         const int buflen = 10;
                         char buf[buflen] = { 0 };
                         int len = 0;
-                        p = const_cast<char*>( XMLUtil::GetCharacterRef( p, buf, &len ) );
-                        TIXMLASSERT( 0 <= len && len <= buflen );
-                        TIXMLASSERT( q + len <= p );
-                        memcpy( q, buf, len );
-                        q += len;
+                        char* adjusted = const_cast<char*>( XMLUtil::GetCharacterRef( p, buf, &len ) );
+                        if ( adjusted == 0 ) {
+                            *q = *p;
+                            ++p;
+                            ++q;
+                        }
+                        else {
+                            TIXMLASSERT( 0 <= len && len <= buflen );
+                            TIXMLASSERT( q + len <= adjusted );
+                            p = adjusted;
+                            memcpy( q, buf, len );
+                            q += len;
+                        }
                     }
                     else {
                         int i=0;

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1416,6 +1416,16 @@ int main( int argc, const char ** argv )
 		XMLPrinter printer;
 	}
 
+	{
+		// Issue 291. Should not crash
+		const char* xml = "&#0</a>";
+		XMLDocument doc;
+		doc.Parse( xml );
+
+		XMLPrinter printer;
+		doc.Print( &printer );
+	}
+
 	// ----------- Performance tracking --------------
 	{
 #if defined( _MSC_VER )


### PR DESCRIPTION
This resolves https://github.com/leethomason/tinyxml2/issues/291