### PR TITLE
Issue 299 - Printing orphan elements

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2297,8 +2297,12 @@ bool XMLPrinter::VisitEnter( const XMLDocument& doc )
 
 bool XMLPrinter::VisitEnter( const XMLElement& element, const XMLAttribute* attribute )
 {
-	const XMLElement*	parentElem = element.Parent()->ToElement();
-	bool		compactMode = parentElem ? CompactMode(*parentElem) : _compactMode;
+    const XMLElement*	parentElem = NULL;
+    if (  element.Parent() )
+    {
+	parentElem = element.Parent()->ToElement();
+    }
+    bool		compactMode = parentElem ? CompactMode(*parentElem) : _compactMode;
     OpenElement( element.Name(), compactMode );
     while ( attribute ) {
         PushAttribute( attribute->Name(), attribute->Value() );

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1425,6 +1425,14 @@ int main( int argc, const char ** argv )
 		XMLPrinter printer;
 		doc.Print( &printer );
 	}
+	{
+		// Issue 299. Can print elements that are not linked in. 
+		// Will crash if issue not fixed.
+		XMLDocument doc;
+		XMLElement* newElement = doc.NewElement( "printme" );
+		XMLPrinter printer;
+		newElement->Accept( &printer );
+	}
 
 	// ----------- Performance tracking --------------
 	{


### PR DESCRIPTION
This stops VisitEnter from segfaulting with an orphan element. Everything else seems to work., with respect to printing.

Added a test that will segfault without the fix.