### PR TITLE
Simplify overengineered code

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -760,7 +760,7 @@ public:
     }
 
     XMLNode*		LastChild()								{
-        return const_cast<XMLNode*>(const_cast<const XMLNode*>(this)->LastChild() );
+        return _lastChild;
     }
 
     /** Get the last child element or optionally the last child


### PR DESCRIPTION
No point in redirecting the call when all is needed is to return a member variable.