### PR TITLE
Detect parsing error earlier when looking at end of tag

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1539,14 +1539,14 @@ char* XMLElement::ParseAttributes( char* p )
             prevAttribute = attrib;
         }
         // end of the tag
-        else if ( *p == '/' && *(p+1) == '>' ) {
-            _closingType = CLOSED;
-            return p+2;	// done; sealed element.
-        }
-        // end of the tag
         else if ( *p == '>' ) {
             ++p;
             break;
+        }
+        // end of the tag
+        else if ( *p == '/' && *(p+1) == '>' ) {
+            _closingType = CLOSED;
+            return p+2;	// done; sealed element.
         }
         else {
             _document->SetError( XML_ERROR_PARSING_ELEMENT, start, p );


### PR DESCRIPTION
Current code instructs to check the first character again when observing `/anything`.