### PR TITLE
Range check without clang "always true" warning

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1958,6 +1958,9 @@ void XMLDocument::PrintError() const
             TIXML_SNPRINTF( buf2, LEN, "%s", _errorStr2 );
         }
 
+        // Should check INT_MIN <= _errorID && _errorId <= INT_MAX, but that
+        // causes a clang "always true" -Wtautological-constant-out-of-range-compare warning
+        TIXMLASSERT( 0 <= _errorID && XML_ERROR_COUNT - 1 <= INT_MAX );
         printf( "XMLDocument error id=%d '%s' str1=%s str2=%s\n",
                 static_cast<int>( _errorID ), ErrorName(), buf1, buf2 );
     }


### PR DESCRIPTION
Undo the change from https://github.com/leethomason/tinyxml2/commit/4f0c2ffcab133bdf43a480c3391caef9be5acb61 without warning emission