### PR TITLE
Avoid unneeded printer object creation

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1928,11 +1928,13 @@ XMLError XMLDocument::Parse( const char* p, size_t len )
 
 void XMLDocument::Print( XMLPrinter* streamer ) const
 {
-    XMLPrinter stdStreamer( stdout );
-    if ( !streamer ) {
-        streamer = &stdStreamer;
+    if ( streamer ) {
+        Accept( streamer );
     }
-    Accept( streamer );
+    else {
+        XMLPrinter stdoutStreamer( stdout );
+        Accept( &stdoutStreamer );
+    }
 }
 
 


### PR DESCRIPTION
Maybe I don't get something but crafting the default printer object at all times looks redundant.