### PR TITLE
When parsing XML Declaration, check if it is being added in the correct place.

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -886,7 +886,18 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEnd )
             }
             break;
         }
-
+        
+        XMLElement* ele = node->ToDeclaration();
+        if ( decl ) {
+        	// A declaration can only be the first child of a document.
+        	// Set error, if document already has children.
+        	if ( ! _document->NoChildren() ) {
+        		_document->SetError(XML_ERROR_PARSING_DECLARATION, decl->Value(), 0);
+        		DeleteNode( decl );
+        		break;
+        	}
+        }
+        
         XMLElement* ele = node->ToElement();
         if ( ele ) {
             // We read the end tag. Return it to the parent.

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -887,7 +887,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEnd )
             break;
         }
 
-        XMLElement* ele = node->ToDeclaration();
+        XMLDeclaration* decl = node->ToDeclaration();
         if ( decl ) {
                 // A declaration can only be the first child of a document.
                 // Set error, if document already has children.

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -886,18 +886,18 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEnd )
             }
             break;
         }
-        
+
         XMLElement* ele = node->ToDeclaration();
         if ( decl ) {
-        	// A declaration can only be the first child of a document.
-        	// Set error, if document already has children.
-        	if ( ! _document->NoChildren() ) {
-        		_document->SetError(XML_ERROR_PARSING_DECLARATION, decl->Value(), 0);
-        		DeleteNode( decl );
-        		break;
-        	}
+                // A declaration can only be the first child of a document.
+                // Set error, if document already has children.
+                if ( !_document->NoChildren() ) {
+                        _document->SetError( XML_ERROR_PARSING_DECLARATION, decl->Value(), 0);
+                        DeleteNode( decl );
+                        break;
+                }
         }
-        
+
         XMLElement* ele = node->ToElement();
         if ( ele ) {
             // We read the end tag. Return it to the parent.

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1459,6 +1459,25 @@ int main( int argc, const char ** argv )
 		doc.LoadFile( "resources/dream.xml" );
 		XMLTest( "Error should be cleared", false, doc.Error() );
 	}
+	
+	{
+		// Check that declarations are parsed only as the FirstChild
+        	const char* xml0 =  	"<?xml version=\"1.0\" ?>"
+        				"   <!-- xml version=\"1.1\" -->"
+        				"<first />";
+        	const char* xml1 =  	"<?xml version=\"1.0\" ?>"
+        				"   <?xml version=\"1.1\" ?>"
+        				"<first />";
+        	const char* xml2 =  	"<first />"
+        				"<?xml version=\"1.0\" ?>";
+        	XMLDocument doc;
+        	doc.Parse(xml0);
+        	XMLTest("Test that the code changes do not affect normal parsing", doc.Error(), false);
+        	doc.Parse(xml1);
+        	XMLTest("Test that the second declaration throws an error", doc.Error(), true);
+        	doc.Parse(xml2);
+        	XMLTest("Test that declaration after a child throws an error", doc.Error(), true);
+	}
 
 	// ----------- Performance tracking --------------
 	{

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1459,24 +1459,24 @@ int main( int argc, const char ** argv )
 		doc.LoadFile( "resources/dream.xml" );
 		XMLTest( "Error should be cleared", false, doc.Error() );
 	}
-	
+
 	{
 		// Check that declarations are parsed only as the FirstChild
-        	const char* xml0 =  	"<?xml version=\"1.0\" ?>"
-        				"   <!-- xml version=\"1.1\" -->"
-        				"<first />";
-        	const char* xml1 =  	"<?xml version=\"1.0\" ?>"
-        				"   <?xml version=\"1.1\" ?>"
-        				"<first />";
-        	const char* xml2 =  	"<first />"
-        				"<?xml version=\"1.0\" ?>";
-        	XMLDocument doc;
-        	doc.Parse(xml0);
-        	XMLTest("Test that the code changes do not affect normal parsing", doc.Error(), false);
-        	doc.Parse(xml1);
-        	XMLTest("Test that the second declaration throws an error", doc.Error(), true);
-        	doc.Parse(xml2);
-        	XMLTest("Test that declaration after a child throws an error", doc.Error(), true);
+                const char* xml0 = "<?xml version=\"1.0\" ?>"
+                                   "   <!-- xml version=\"1.1\" -->"
+                                   "<first />";
+                const char* xml1 = "<?xml version=\"1.0\" ?>"
+                                   "   <?xml version=\"1.1\" ?>"
+                                   "<first />";
+                const char* xml2 = "<first />"
+                                   "<?xml version=\"1.0\" ?>";
+                XMLDocument doc;
+                doc.Parse(xml0);
+                XMLTest("Test that the code changes do not affect normal parsing", doc.Error(), false);
+                doc.Parse(xml1);
+                XMLTest("Test that the second declaration throws an error", doc.Error(), true);
+                doc.Parse(xml2);
+                XMLTest("Test that declaration after a child throws an error", doc.Error(), true);
 	}
 
 	// ----------- Performance tracking --------------


### PR DESCRIPTION
XML Declarations can only occur at the very beginning of an XML Document.
Test cases added, to check this.
ParseDeep() fixed, to pass test cases.

This fix should close #332 