### PR TITLE
Assert fires when calling xml document  value

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -645,6 +645,8 @@ XMLNode::~XMLNode()
 
 const char* XMLNode::Value() const 
 {
+    if ( this->ToDocument() )
+        return ( const char* )0;
     return _value.GetStr();
 }
 

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -646,7 +646,7 @@ XMLNode::~XMLNode()
 const char* XMLNode::Value() const 
 {
     if ( this->ToDocument() )
-        return ( const char* )0;
+        return 0;
     return _value.GetStr();
 }
 

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -708,7 +708,7 @@ public:
 
     /** The meaning of 'value' changes for the specific type.
     	@verbatim
-    	Document:	empty
+    	Document:	empty (NULL is returned, not an empty string)
     	Element:	name of the element
     	Comment:	the comment text
     	Unknown:	the tag contents

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -35,7 +35,8 @@ bool XMLTest (const char* testString, const char* expected, const char* found, b
 		pass = true;
 	else if ( !expected || !found )
 		pass = false;
-	else pass = !strcmp( expected, found );
+	else 
+		pass = !strcmp( expected, found );
 	if ( pass )
 		printf ("[pass]");
 	else
@@ -1472,7 +1473,6 @@ int main( int argc, const char ** argv )
                                        "<first />"
                                        "<second />";
                 XMLDocument* doc = new XMLDocument();
-                const char* value;
                 XMLTest( "XMLDocument::Value() fires assert?", NULL, doc->Value() );
                 doc->Parse( validXml );
                 XMLTest( "XMLDocument::Value() fires assert?", NULL, doc->Value() );

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1460,7 +1460,21 @@ int main( int argc, const char ** argv )
 		XMLTest( "Error should be cleared", false, doc.Error() );
 	}
 
-	// ----------- Performance tracking --------------
+        {
+                // No matter - before or after successfully parsing a text -
+                // calling XMLDocument::Value() causes an assert in debug.
+                const char* validXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
+                                       "<first />"
+                                       "<second />";
+                XMLDocument* doc = new XMLDocument();
+                const char* value;
+                XMLTest( "XMLDocument::Value() fires assert?", NULL, doc->Value() );
+                doc->Parse( validXml );
+                XMLTest( "XMLDocument::Value() fires assert?", NULL, doc->Value() );
+                delete doc;
+        }
+
+        // ----------- Performance tracking --------------
 	{
 #if defined( _MSC_VER )
 		__int64 start, end, freq;

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -30,7 +30,12 @@ int gFail = 0;
 
 bool XMLTest (const char* testString, const char* expected, const char* found, bool echo=true, bool extraNL=false )
 {
-	bool pass = !strcmp( expected, found );
+	bool pass;
+	if ( !expected && !found )
+		pass = true;
+	else if ( !expected || !found )
+		pass = false;
+	else pass = !strcmp( expected, found );
 	if ( pass )
 		printf ("[pass]");
 	else


### PR DESCRIPTION
In this patch:

* Add a test case in xmltest.cpp, for `XMLDocument::Value()`
* Handle null pointers in `XMLTest()`
* Fix Issue #323, by bypassing function call
* Clarify explicitly, the meaning of 'empty' in `XMLDocument::Value()` documentation.