### PR TITLE
Explicitly check entity was not found

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -243,8 +243,8 @@ const char* StrPair::GetStr()
                         }
                     }
                     else {
-                        int i=0;
-                        for(; i<NUM_ENTITIES; ++i ) {
+                        bool entityFound = false;
+                        for( int i = 0; i < NUM_ENTITIES; ++i ) {
                             const Entity& entity = entities[i];
                             if ( strncmp( p + 1, entity.pattern, entity.length ) == 0
                                     && *( p + entity.length + 1 ) == ';' ) {
@@ -252,10 +252,11 @@ const char* StrPair::GetStr()
                                 *q = entity.value;
                                 ++q;
                                 p += entity.length + 2;
+                                entityFound = true;
                                 break;
                             }
                         }
-                        if ( i == NUM_ENTITIES ) {
+                        if ( !entityFound ) {
                             // fixme: treat as error?
                             ++p;
                             ++q;


### PR DESCRIPTION
I know that the original code follows a nearly idiomatic pattern. However this pattern requires that you have the range check together with the upper limit duplicated and also couple the after-loop check with the loop logic. It's cleaner to make this with an explicitly named flag variable.