### PR TITLE
Don't use -1 as buffer length

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2041,12 +2041,16 @@ void XMLPrinter::Print( const char* format, ... )
 #if defined(_MSC_VER) && (_MSC_VER >= 1400 )
 		#if defined(WINCE)
 		int len = 512;
-		do {
+        for (;;) {
 		    len = len*2;
 		    char* str = new char[len]();
-			len = _vsnprintf(str, len, format, va);
+            const int required = _vsnprintf(str, len, format, va);
 			delete[] str;
-		}while (len < 0);
+            if ( required != -1 ) {
+                len = required;
+                break;
+            }
+        }
 		#else
         int len = _vscprintf( format, va );
 		#endif


### PR DESCRIPTION
The original code is broken. It starts with `len=512`, doubles it, then if the string is so large it doesn't fit then `len` becomes `-1`  which is then doubled (becomes -2) and that value is passed into `new[]` which most likely makes the program crash with `bad_alloc`.