### PR TITLE
Better document warning suppression code

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1769,7 +1769,8 @@ XMLDocument::XMLDocument( bool processEntities, Whitespace whitespace ) :
     _errorStr2( 0 ),
     _charBuffer( 0 )
 {
-    _document = this;	// avoid warning about 'this' in initializer list
+    // avoid VC++ C4355 warning about 'this' in initializer list (C4355 is off by default in VS2012+)
+    _document = this;
 }
 
 


### PR DESCRIPTION
The current comment fails to mention that the warning is specific to VC. Also you cannot imagine how surprised I was when I rewrote this "properly", compiled with VS2012 and saw no warning - turns out MS folks simply turned it off by default. This should be proper documented to ensure clean compilation on older versions.