### PR TITLE
fix compiler warning (XCode 4.6.1 x86_64) tinyxml2.cpp:2146:77: Impli…

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2143,7 +2143,7 @@ void XMLPrinter::PrintString( const char* p, bool restricted )
                     while ( p < q ) {
                         const size_t delta = q - p;
                         // %.*s accepts type int as "precision"
-                        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : delta;
+                        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
                         Print( "%.*s", toPrint, p );
                         p += toPrint;
                     }


### PR DESCRIPTION
…cit conversion loses integer precision: 'const size_t' (aka 'const unsigned long') to 'const int'