### PR TITLE
CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: cpp
-compiler: 
+
+os:
+  - linux
+  - osx
+
+compiler:
   - g++
   - clang
-os: linux
 
-before_script: cmake . 
-script: make && ./xmltest
+before_script: cmake .
+
+script:
+  - make -j3
+  - ./xmltest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,7 @@
+before_build:
+  - cmake .
+
+build_script:
+  - msbuild tinyxml2.sln /m /p:Configuration=Release /t:ALL_BUILD
+  - copy Release\xmltest.exe .\ && copy Release\tinyxml2.dll .\
+  - xmltest.exe

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-TinyXML-2
+TinyXML-2 [![TravisCI Status](https://travis-ci.org/leethomason/tinyxml2.svg?branch=master)](https://travis-ci.org/leethomason/tinyxml2) [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/leethomason/tinyxml2?branch=master&svg=true)](https://ci.appveyor.com/project/leethomason/tinyxml2)
 =========
 ![TinyXML-2 Logo](http://www.grinninglizard.com/tinyxml2/TinyXML2_small.png)
 


### PR DESCRIPTION
Added configuration file for [appveyor service](https://ci.appveyor.com), the service is based on windows.
Here is the log: https://ci.appveyor.com/project/Chocobo1/tinyxml2/build/1.0.2

Added building on OS X on TravisCI. Log here: https://travis-ci.org/Chocobo1/tinyxml2/builds/83310669

Preview status badges (you haven't registered on appveyor, so currently it's not displaying status icon but fallback text): https://github.com/Chocobo1/tinyxml2/blob/travis/readme.md