### PR TITLE
Fix warnings when building using SunCC

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2172,8 +2172,8 @@ void XMLPrinter::PrintString( const char* p, bool restricted )
                     while ( p < q ) {
                         const size_t delta = q - p;
                         // %.*s accepts type int as "precision"
-                        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
-                        Print( "%.*s", toPrint, p );
+                        const size_t toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
+                        Print( "%.*zu", toPrint, p );
                         p += toPrint;
                     }
                     bool entityPatternPrinted = false;


### PR DESCRIPTION
When building using the Sun CC on Solaris I get the following warnings:
"tinyxml2.cpp", line 2075: Warning, truncwarn: Conversion of 64 bit type value to "const int" causes truncation.
"tinyxml2.cpp", line 2075: Warning, truncwarn: Conversion of 64 bit type value to "const int" causes truncation.

These changes fixes that.