### PR TITLE
Unlink before deletechild

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -776,6 +776,7 @@ void XMLNode::DeleteChild( XMLNode* node )
     TIXMLASSERT( node );
     TIXMLASSERT( node->_document == _document );
     TIXMLASSERT( node->_parent == this );
+	Unlink(node);
     DeleteNode( node );
 }
 


### PR DESCRIPTION
Added call to Unlink in XMLNode::DeleteChild().

This will make sure the child can be safely deleted (and consistent with
the code in void XMLNode::DeleteChildren())