### PR TITLE
Error fix DeleteChild

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -776,6 +776,7 @@ void XMLNode::DeleteChild( XMLNode* node )
     TIXMLASSERT( node );
     TIXMLASSERT( node->_document == _document );
     TIXMLASSERT( node->_parent == this );
+    Unlink( node );
     DeleteNode( node );
 }
 


### PR DESCRIPTION
Added call to Unlink in XMLNode::DeleteChild() so that references to
node are removed before memory is unallocated. This will ensure the
child is removed from parent and that no pointers are referring to the
unallocated memory. (Code is now aligned with the code in
XMLNode::DeleteChildren() )