### PR TITLE
Assert to ensure ftell() behaves as expected by later code

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1954,6 +1954,7 @@ XMLError XMLDocument::LoadFile( FILE* fp )
         SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
         return _errorID;
     }
+    TIXMLASSERT( filelength >= 0 );
 
     if ( !LongFitsIntoSizeTMinusOne<>::Fits( filelength ) ) {
         // Cannot handle files which won't fit in buffer together with null terminator


### PR DESCRIPTION
It won't hurt to explain that there're no negative return values to expect from `ftell()` other than already handled `-1L`. This may save if there's an stdlib behaving unexpectedly.