### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -265,7 +265,7 @@ And additionally a test file:
 * xmltest.cpp
 
 Simply compile and run. There is a visual studio 2010 project included, a simple Makefile, 
-an XCode project, a Code::Blocks project, and a cmake CMakeLists.txt included to help you. 
+an Xcode project, a Code::Blocks project, and a cmake CMakeLists.txt included to help you. 
 The top of tinyxml.h even has a simple g++ command line if you are are *nix and don't want 
 to use a build system.
 


### PR DESCRIPTION

This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
