### PR TITLE
XMLPrinter optimization

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2038,6 +2038,9 @@ protected:
 	*/
     virtual void PrintSpace( int depth );
     void Print( const char* format, ... );
+    void Write( const char* data, size_t size );
+    inline void Write( const char* data )           { Write( data, strlen( data ) ); }
+    void Putc( char ch );
 
 	void SealElement();
     bool _elementJustOpened;


### PR DESCRIPTION
Streaming writing to buffer will be x5 faster

I'm using TinyXML2 v2.0.2 for a streaming writing of the big documents through buffer (make part of document -> write buffer to file -> clean buffer -> step 0). This changes makes our tools x2 faster, and serialization more then x5 faster separately.

Storing across the Print consumed 62% CPU in our case. Now storing across the Write/Putc consumed 11% CPU.
