### PR TITLE
Updated Makefile to allow building TinyXML2 as a static library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
-all: xmltest
-xmltest: xmltest.cpp tinyxml2.cpp tinyxml2.h
+all: xmltest staticlib
+
+rebuild: clean all
+
+xmltest: xmltest.cpp tinyxml2.a
+
+clean:
+	$(RM) *.o xmltest tinyxml2.a
+	
 test: clean xmltest
 	./xmltest
-clean:
-	rm -f *.o xmltest
+
+staticlib: tinyxml2.a
+
+tinyxml2.a: tinyxml2.o
+	$(AR) $(ARFLAGS)s $@ $^
+	
+tinyxml2.o: tinyxml2.cpp tinyxml2.h
+


### PR DESCRIPTION
This patch updates the Makefile to allow building TinyXML2 as a static library on *nix, mimicking Windows' Visual Studio project's behavior.

I tried to keep the Makefile as simple as possible, following the style that was present.

I tried avoiding the line ```$(AR) $(ARFLAGS)s $@ $^```, but the ```s``` was required to build it as a static lib (the default arguments of AR doesn't include that ```s```)

As a plus, I added a new rule to easily rebuild the project.

If you like the idea/patch but want something changed, please, tell me and I'll update it :)

I hope this helps! :smile: