### PR TITLE
Standardized static library output name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,17 @@ all: xmltest staticlib
 
 rebuild: clean all
 
-xmltest: xmltest.cpp tinyxml2.a
+xmltest: xmltest.cpp libtinyxml2.a
 
 clean:
-	$(RM) *.o xmltest tinyxml2.a
+	$(RM) *.o xmltest libtinyxml2.a
 	
 test: clean xmltest
 	./xmltest
 
-staticlib: tinyxml2.a
+staticlib: libtinyxml2.a
 
-tinyxml2.a: tinyxml2.o
+libtinyxml2.a: tinyxml2.o
 	$(AR) $(ARFLAGS)s $@ $^
 	
 tinyxml2.o: tinyxml2.cpp tinyxml2.h


### PR DESCRIPTION
Renamed ```tinyxml2.a``` to ```libtinyxml2.a```, to allow proper linking using the ```-l``` flag on gcc.