### PR TITLE
Fixes issue #425

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1932,10 +1932,12 @@ struct LongFitsIntoSizeTMinusOne {
 };
 
 template <>
-bool LongFitsIntoSizeTMinusOne<false>::Fits( unsigned long /*value*/ )
-{
-    return true;
-}
+struct LongFitsIntoSizeTMinusOne<false> {
+    static bool Fits( unsigned long )
+    {
+        return true;
+    }
+};
 
 XMLError XMLDocument::LoadFile( FILE* fp )
 {


### PR DESCRIPTION
C++Builder doesn't handle well member function specialization (`LongFitsIntoSizeTMinusOne<false>::Fits(unsigned long)`) but a class template specialization seems to work (`template<> struct LongFitsIntoSizeTMinusOne<false>`).

This doesn't imply redundant code since `LongFitsIntoSizeTMinusOne<T>` contains a single method.