### PR TITLE
Pointer initialization check

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -143,7 +143,8 @@ StrPair::~StrPair()
 
 void StrPair::TransferTo( StrPair* other )
 {
-    if ( this == other ) {
+    if ( this == other ||
+    	other == nullptr) {
         return;
     }
     // This in effect implements the assignment operator by "moving"


### PR DESCRIPTION
Just a simple check to avoid some warnings from static analysers. Doesn't improve anything, but it won't yield any warning