### PR TITLE
ELF visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,9 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 option(BUILD_SHARED_LIBS "build as shared library" ON)
 option(BUILD_STATIC_LIBS "build as static library" OFF)
 
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
 if(BUILD_SHARED_LIBS)
 add_library(tinyxml2 SHARED tinyxml2.cpp tinyxml2.h)
 

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -72,6 +72,8 @@ distribution.
 #   else
 #       define TINYXML2_LIB
 #   endif
+#elif __GNUC__ >= 4
+#   define TINYXML2_LIB __attribute__((visibility("default")))
 #else
 #   define TINYXML2_LIB
 #endif


### PR DESCRIPTION
Improve definition of `TINYXML2_LIB` to specify default symbol visibility on appropriate platforms, allowing consumers to build with `-fvisibility=hidden`. Modify our own build to build with `-fvisibility=hidden` by default (if CMake is sufficiently new).

The updated definition of `TINYXML2_LIB` follows the same pattern used in other places (at least in [swig](https://github.com/swig/swig/blob/master/Lib/swiglabels.swg#L69) and [vivia](https://github.com/Kitware/vivia/blob/master/CMake/gen-export.cmake#L68)), so there is cause to believe the relatively simplistic check to decide how to define it should be sufficient for most platforms. (Support for GCC 3.x or older was left out as these are beyond ancient at this point.)

Fixes #461.