### PR TITLE
Loop invariant pointer assertions

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -191,6 +191,7 @@ void StrPair::SetStr( const char* str, int flags )
 
 char* StrPair::ParseText( char* p, const char* endTag, int strFlags )
 {
+    TIXMLASSERT( p );
     TIXMLASSERT( endTag && *endTag );
 
     char* start = p;
@@ -204,6 +205,7 @@ char* StrPair::ParseText( char* p, const char* endTag, int strFlags )
             return p + length;
         }
         ++p;
+        TIXMLASSERT( p );
     }
     return 0;
 }


### PR DESCRIPTION
`p` is dereferenced on each loop iteration, no harm in clarifying that with assertions