### PR TITLE
Pointer assertions for substring

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -139,6 +139,8 @@ public:
     ~StrPair();
 
     void Set( char* start, char* end, int flags ) {
+        TIXMLASSERT( start );
+        TIXMLASSERT( end );
         Reset();
         _start  = start;
         _end    = end;


### PR DESCRIPTION
"need flush" is being set, so `GetStr()` assertions will surely fire if any of the pointers is null.