### PR TITLE
Unify increments and decrements

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -367,8 +367,8 @@ public:
         if ( _currentAllocs > _maxAllocs ) {
             _maxAllocs = _currentAllocs;
         }
-        _nAllocs++;
-        _nUntracked++;
+        ++_nAllocs;
+        ++_nUntracked;
         return result;
     }
     
@@ -391,7 +391,7 @@ public:
     }
 
     void SetTracked() {
-        _nUntracked--;
+        --_nUntracked;
     }
 
     int Untracked() const {


### PR DESCRIPTION
Pre- and post- manipulations are used with no clear pattern in original code. Just using pre- forms everywhere makes it a bit clearer.