### PR TITLE
Fix warning on PowerPC

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2183,7 +2183,8 @@ XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
     }
     for( int i=0; i<NUM_ENTITIES; ++i ) {
         const char entityValue = entities[i].value;
-        TIXMLASSERT( 0 <= entityValue && entityValue < ENTITY_RANGE );
+        // cast to explicit signed because char may be unsigned (on PowerPC)
+        TIXMLASSERT( 0 <= static_cast<signed char>(entityValue) && entityValue < ENTITY_RANGE );
         _entityFlag[ (unsigned char)entityValue ] = true;
     }
     _restrictedEntityFlag[(unsigned char)'&'] = true;


### PR DESCRIPTION
GCC 5+ will generate "error: comparison is always true due to limited range of data type" when -Wextra is used because PowerPC by default uses unsigned char, so it can never be less than 0.