### PR TITLE
Avoid cast to signed integer type

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2192,8 +2192,7 @@ XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
     }
     for( int i=0; i<NUM_ENTITIES; ++i ) {
         const char entityValue = entities[i].value;
-        // cast to explicit signed because char may be unsigned (on PowerPC)
-        TIXMLASSERT( 0 <= static_cast<signed char>(entityValue) && entityValue < ENTITY_RANGE );
+        TIXMLASSERT( ((unsigned char)entityValue) < ENTITY_RANGE );
         _entityFlag[ (unsigned char)entityValue ] = true;
     }
     _restrictedEntityFlag[(unsigned char)'&'] = true;


### PR DESCRIPTION
Conversion from unsigned to signed is implementation defined for out of range values but conversion from signed to unsigned is well-defined.