### PR TITLE
Pointer post-assertion

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -965,6 +965,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEnd )
         XMLNode* node = 0;
 
         p = _document->Identify( p, &node );
+        TIXMLASSERT( p );
         if ( node == 0 ) {
             break;
         }


### PR DESCRIPTION
`Identify()` never returns null pointers. A post-assertion makes it clearer.