### PR TITLE
Row/column of current element / error? #26

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,9 +88,8 @@ Advantages of TinyXML-2
 
 Advantages of TinyXML-1
 
-1.  Can report the location of parsing errors.
-2.  Support for some C++ STL conventions: streams and strings
-3.  Very mature and well debugged code base.
+1.  Support for some C++ STL conventions: streams and strings
+2.  Very mature and well debugged code base.
 
 Features
 --------
@@ -156,6 +155,15 @@ However, you may also use COLLAPSE_WHITESPACE, which will:
 
 Note that (currently) there is a performance impact for using COLLAPSE_WHITESPACE.
 It essentially causes the XML to be parsed twice.
+
+#### Error Reporting
+
+TinyXML-2 reports the line number of any errors in an XML document that
+cannot be parsed correctly. In addition, all nodes (elements, declarations,
+text, comments etc.) and attributes have a line number recorded as they are parsed.
+This allows an application that performs additional validation of the parsed
+XML document (e.g. application-implemented DTD validation) to report
+line number information in it's errors.
 
 ### Entities
 

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -238,7 +238,7 @@ void StrPair::CollapseWhitespace()
     // Adjusting _start would cause undefined behavior on delete[]
     TIXMLASSERT( ( _flags & NEEDS_DELETE ) == 0 );
     // Trim leading space.
-    int unusedLineNum(0);
+    int unusedLineNum = 0;
     _start = XMLUtil::SkipWhiteSpace( _start, &unusedLineNum );
 
     if ( *_start ) {

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2226,12 +2226,17 @@ void XMLDocument::SetError( XMLError error, const char* str1, const char* str2 )
 		_errorStr2.SetStr(str2);
 }
 
-const char* XMLDocument::ErrorName() const
+const char* XMLDocument::ErrorName(XMLError errorID)
 {
-	TIXMLASSERT( _errorID >= 0 && _errorID < XML_ERROR_COUNT );
-    const char* errorName = _errorNames[_errorID];
+	TIXMLASSERT( errorID >= 0 && errorID < XML_ERROR_COUNT );
+    const char* errorName = _errorNames[errorID];
     TIXMLASSERT( errorName && errorName[0] );
     return errorName;
+}
+
+const char* XMLDocument::ErrorName() const
+{
+    return ErrorName(_errorID);
 }
 
 void XMLDocument::PrintError() const

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -982,14 +982,14 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEnd, int* curLineNumPtr )
             break;
         }
 
-        int nodeLineNum = node->_parseLineNum;
+        int initialLineNum = node->_parseLineNum;
 
         StrPair endTag;
         p = node->ParseDeep( p, &endTag, curLineNumPtr );
         if ( !p ) {
             DeleteNode( node );
             if ( !_document->Error() ) {
-                _document->SetError( XML_ERROR_PARSING, 0, 0, nodeLineNum );
+                _document->SetError( XML_ERROR_PARSING, 0, 0, initialLineNum);
             }
             break;
         }
@@ -1009,7 +1009,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEnd, int* curLineNumPtr )
                 }
             }
             if ( !wellLocated ) {
-                _document->SetError( XML_ERROR_PARSING_DECLARATION, decl->Value(), 0, nodeLineNum );
+                _document->SetError( XML_ERROR_PARSING_DECLARATION, decl->Value(), 0, initialLineNum);
                 DeleteNode( node );
                 break;
             }
@@ -1044,7 +1044,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEnd, int* curLineNumPtr )
                 }
             }
             if ( mismatch ) {
-                _document->SetError( XML_ERROR_MISMATCHED_ELEMENT, ele->Name(), 0, nodeLineNum );
+                _document->SetError( XML_ERROR_MISMATCHED_ELEMENT, ele->Name(), 0, initialLineNum);
                 DeleteNode( node );
                 break;
             }

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -710,7 +710,7 @@ public:
     void SetValue( const char* val, bool staticMem=false );
 
     /// Gets the line number the node is in, if the document was parsed from a file.
-    int GetParseLineNum() const { return _parseLineNum; }
+    int GetLineNum() const { return _parseLineNum; }
 
     /// Get the parent of this node on the DOM.
     const XMLNode*	Parent() const			{
@@ -1094,7 +1094,7 @@ public:
     const char* Value() const;
 
     /// Gets the line number the attribute is in, if the document was parsed from a file.
-    int GetParseLineNum() const { return _parseLineNum; }
+    int GetLineNum() const { return _parseLineNum; }
 
     /// The next attribute in the list.
     const XMLAttribute* Next() const {

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1749,6 +1749,7 @@ public:
         return _errorID;
     }
 	const char* ErrorName() const;
+    static const char* ErrorName(XMLError errorID);
 
     /// Return a possibly helpful diagnostic location or string.
     const char* GetErrorStr1() const {

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -160,7 +160,7 @@ public:
 
     void SetStr( const char* str, int flags=0 );
 
-    char* ParseText( char* in, const char* endTag, int strFlags, int& curLineNum );
+    char* ParseText( char* in, const char* endTag, int strFlags, int* curLineNumPtr );
     char* ParseName( char* in );
 
     void TransferTo( StrPair* other );
@@ -530,19 +530,19 @@ enum XMLError {
 class XMLUtil
 {
 public:
-    static const char* SkipWhiteSpace( const char* p, int& curLineNum )	{
+    static const char* SkipWhiteSpace( const char* p, int* curLineNumPtr )	{
         TIXMLASSERT( p );
         while( IsWhiteSpace(*p) ) {
             if (*p == '\n') {
-                ++curLineNum;
+                ++(*curLineNumPtr);
             }
             ++p;
         }
         TIXMLASSERT( p );
         return p;
     }
-    static char* SkipWhiteSpace( char* p, int& curLineNum )				{
-        return const_cast<char*>( SkipWhiteSpace( const_cast<const char*>(p), curLineNum ) );
+    static char* SkipWhiteSpace( char* p, int* curLineNumPtr )				{
+        return const_cast<char*>( SkipWhiteSpace( const_cast<const char*>(p), curLineNumPtr ) );
     }
 
     // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
@@ -895,7 +895,7 @@ protected:
     XMLNode( XMLDocument* );
     virtual ~XMLNode();
 
-    virtual char* ParseDeep( char*, StrPair*, int& );
+    virtual char* ParseDeep( char*, StrPair*, int* );
 
     XMLDocument*	_document;
     XMLNode*		_parent;
@@ -963,7 +963,7 @@ protected:
     XMLText( XMLDocument* doc )	: XMLNode( doc ), _isCData( false )	{}
     virtual ~XMLText()												{}
 
-    char* ParseDeep( char*, StrPair* endTag, int& curLineNum );
+    char* ParseDeep( char*, StrPair* endTag, int* curLineNumPtr );
 
 private:
     bool _isCData;
@@ -994,7 +994,7 @@ protected:
     XMLComment( XMLDocument* doc );
     virtual ~XMLComment();
 
-    char* ParseDeep( char*, StrPair* endTag, int& curLineNum);
+    char* ParseDeep( char*, StrPair* endTag, int* curLineNumPtr);
 
 private:
     XMLComment( const XMLComment& );	// not supported
@@ -1033,7 +1033,7 @@ protected:
     XMLDeclaration( XMLDocument* doc );
     virtual ~XMLDeclaration();
 
-    char* ParseDeep( char*, StrPair* endTag, int& curLineNum );
+    char* ParseDeep( char*, StrPair* endTag, int* curLineNumPtr );
 
 private:
     XMLDeclaration( const XMLDeclaration& );	// not supported
@@ -1068,7 +1068,7 @@ protected:
     XMLUnknown( XMLDocument* doc );
     virtual ~XMLUnknown();
 
-    char* ParseDeep( char*, StrPair* endTag, int& curLineNum );
+    char* ParseDeep( char*, StrPair* endTag, int* curLineNumPtr );
 
 private:
     XMLUnknown( const XMLUnknown& );	// not supported
@@ -1183,7 +1183,7 @@ private:
     void operator=( const XMLAttribute& );	// not supported
     void SetName( const char* name );
 
-    char* ParseDeep( char* p, bool processEntities, int& curLineNum );
+    char* ParseDeep( char* p, bool processEntities, int* curLineNumPtr );
 
     mutable StrPair _name;
     mutable StrPair _value;
@@ -1559,7 +1559,7 @@ public:
     virtual bool ShallowEqual( const XMLNode* compare ) const;
 
 protected:
-    char* ParseDeep( char* p, StrPair* endTag, int& curLineNum );
+    char* ParseDeep( char* p, StrPair* endTag, int* curLineNumPtr );
 
 private:
     XMLElement( XMLDocument* doc );
@@ -1572,7 +1572,7 @@ private:
     }
     XMLAttribute* FindOrCreateAttribute( const char* name );
     //void LinkAttribute( XMLAttribute* attrib );
-    char* ParseAttributes( char* p, int& curLineNum );
+    char* ParseAttributes( char* p, int* curLineNumPtr );
     static void DeleteAttribute( XMLAttribute* attribute );
     XMLAttribute* CreateAttribute();
 

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1687,34 +1687,34 @@ int main( int argc, const char ** argv )
 
             bool VisitEnter(const XMLDocument& doc)
             {
-                Push('D', doc.GetParseLineNum());
+                Push('D', doc.GetLineNum());
                 return true;
             }
             bool VisitEnter(const XMLElement& element, const XMLAttribute* firstAttribute)
             {
-                Push('E', element.GetParseLineNum());
+                Push('E', element.GetLineNum());
                 for (const XMLAttribute *attr = firstAttribute; attr != 0; attr = attr->Next())
-                    Push('A', attr->GetParseLineNum());
+                    Push('A', attr->GetLineNum());
                 return true;
             }
             bool Visit(const XMLDeclaration& declaration)
             {
-                Push('L', declaration.GetParseLineNum());
+                Push('L', declaration.GetLineNum());
                 return true;
             }
             bool Visit(const XMLText& text)
             {
-                Push('T', text.GetParseLineNum());
+                Push('T', text.GetLineNum());
                 return true;
             }
             bool Visit(const XMLComment& comment)
             {
-                Push('C', comment.GetParseLineNum());
+                Push('C', comment.GetLineNum());
                 return true;
             }
             bool Visit(const XMLUnknown& unknown)
             {
-                Push('U', unknown.GetParseLineNum());
+                Push('U', unknown.GetLineNum());
                 return true;
             }
 

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -63,6 +63,15 @@ bool XMLTest (const char* testString, const char* expected, const char* found, b
 	return pass;
 }
 
+bool XMLTest(const char* testString, XMLError expected, XMLError found, bool echo = true, bool extraNL = false)
+{
+    return XMLTest(testString, XMLDocument::ErrorName(expected), XMLDocument::ErrorName(found), echo, extraNL);
+}
+
+bool XMLTest(const char* testString, bool expected, bool found, bool echo = true, bool extraNL = false)
+{
+    return XMLTest(testString, expected ? "true" : "false", found ? "true" : "false", echo, extraNL);
+}
 
 template< class T > bool XMLTest( const char* testString, T expected, T found, bool echo=true )
 {

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1640,10 +1640,135 @@ int main( int argc, const char ** argv )
 	{
 		XMLDocument doc;
 		for( int i = 0; i < XML_ERROR_COUNT; i++ ) {
-			doc.SetError( (XMLError)i, 0, 0 );
+			doc.SetError( (XMLError)i, 0, 0, 0 );
 			doc.ErrorName();
 		}
 	}
+
+    // ----------- Line Number Tracking --------------
+    {
+        struct Functor: XMLVisitor
+        {
+            void TestParseError(const char *testString, const char *docStr, XMLError expected_error, int expectedLine)
+            {
+                XMLDocument doc;
+                XMLError err = doc.Parse(docStr);
+
+                XMLTest(testString, true, doc.Error());
+                XMLTest(testString, expected_error, err);
+                XMLTest(testString, expectedLine, doc.GetErrorLineNum());
+            };
+
+            void TestStringLines(const char *testString, const char *docStr, const char *expectedLines)
+            {
+                XMLDocument doc;
+                doc.Parse(docStr);
+                XMLTest(testString, false, doc.Error());
+                TestDocLines(testString, doc, expectedLines);
+            }
+
+            void TestFileLines(const char *testString, const char *file_name, const char *expectedLines)
+            {
+                XMLDocument doc;
+                doc.LoadFile(file_name);
+                XMLTest(testString, false, doc.Error());
+                TestDocLines(testString, doc, expectedLines);
+            }
+
+        private:
+            DynArray<char, 10> str;
+
+            void Push(char type, int lineNum)
+            {
+                str.Push(type);
+                str.Push(char('0' + (lineNum / 10)));
+                str.Push(char('0' + (lineNum % 10)));
+            }
+
+            bool VisitEnter(const XMLDocument& doc)
+            {
+                Push('D', doc.GetParseLineNum());
+                return true;
+            }
+            bool VisitEnter(const XMLElement& element, const XMLAttribute* firstAttribute)
+            {
+                Push('E', element.GetParseLineNum());
+                for (const XMLAttribute *attr = firstAttribute; attr != 0; attr = attr->Next())
+                    Push('A', attr->GetParseLineNum());
+                return true;
+            }
+            bool Visit(const XMLDeclaration& declaration)
+            {
+                Push('L', declaration.GetParseLineNum());
+                return true;
+            }
+            bool Visit(const XMLText& text)
+            {
+                Push('T', text.GetParseLineNum());
+                return true;
+            }
+            bool Visit(const XMLComment& comment)
+            {
+                Push('C', comment.GetParseLineNum());
+                return true;
+            }
+            bool Visit(const XMLUnknown& unknown)
+            {
+                Push('U', unknown.GetParseLineNum());
+                return true;
+            }
+
+            void TestDocLines(const char *testString, XMLDocument &doc, const char *expectedLines)
+            {
+                str.Clear();
+                doc.Accept(this);
+                str.Push(0);
+                XMLTest(testString, expectedLines, str.Mem());
+            }
+        } T;
+
+        T.TestParseError("ErrorLine-Parsing", "\n<root>\n foo \n<unclosed/>", XML_ERROR_PARSING, 2);
+        T.TestParseError("ErrorLine-Declaration", "<root>\n<?xml version=\"1.0\"?>", XML_ERROR_PARSING_DECLARATION, 2);
+        T.TestParseError("ErrorLine-Mismatch", "\n<root>\n</mismatch>", XML_ERROR_MISMATCHED_ELEMENT, 2);
+        T.TestParseError("ErrorLine-CData", "\n<root><![CDATA[ \n foo bar \n", XML_ERROR_PARSING_CDATA, 2);
+        T.TestParseError("ErrorLine-Text", "\n<root>\n foo bar \n", XML_ERROR_PARSING_TEXT, 3);
+        T.TestParseError("ErrorLine-Comment", "\n<root>\n<!-- >\n", XML_ERROR_PARSING_COMMENT, 3);
+        T.TestParseError("ErrorLine-Declaration", "\n<root>\n<? >\n", XML_ERROR_PARSING_DECLARATION, 3);
+        T.TestParseError("ErrorLine-Unknown", "\n<root>\n<! \n", XML_ERROR_PARSING_UNKNOWN, 3);
+        T.TestParseError("ErrorLine-Element", "\n<root>\n<unclosed \n", XML_ERROR_PARSING_ELEMENT, 3);
+        T.TestParseError("ErrorLine-Attribute", "\n<root>\n<unclosed \n att\n", XML_ERROR_PARSING_ATTRIBUTE, 4);
+        T.TestParseError("ErrorLine-ElementClose", "\n<root>\n<unclosed \n/unexpected", XML_ERROR_PARSING_ELEMENT, 3);
+
+        T.TestStringLines(
+            "LineNumbers-String",
+            "<?xml version=\"1.0\"?>\n"
+                "<root a='b' \n"
+                "c='d'> d <blah/>  \n"
+                "newline in text \n"
+                "and second <zxcv/><![CDATA[\n"
+                " cdata test ]]><!-- comment -->\n"
+                "<! unknown></root>",
+            "D01L01E02A02A03T03E03T04E05T05C06U07");
+
+        T.TestStringLines(
+            "LineNumbers-CRLF",
+            "\r\n"
+            "<?xml version=\"1.0\"?>\n"
+            "<root>\r\n"
+            "\n"
+            "text contining new line \n"
+            " and also containing crlf \r\n"
+            "<sub><![CDATA[\n"
+            "cdata containing new line \n"
+            " and also containing cflr\r\n"
+            "]]></sub><sub2/></root>",
+            "D01L02E03T05E07T07E10");
+
+        T.TestFileLines(
+            "LineNumbers-File",
+            "resources/utf8test.xml",
+            "D01L01E02E03A03A03T03E04A04A04T04E05A05A05T05E06A06A06T06E07A07A07T07E08A08A08T08E09T09E10T10");
+    }
 
     // ----------- Performance tracking --------------
 	{


### PR DESCRIPTION
Row/column of current element / error? #26 
Supported reporting the row of errors, all nodes, and all attributes.
Column information is not supported.