### PR TITLE
Bool serialization.

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -368,6 +368,25 @@ const char* StrPair::GetStr()
 
 // --------- XMLUtil ----------- //
 
+char* XMLUtil::writeBoolTrue  = "true";
+char* XMLUtil::writeBoolFalse = "false";
+
+void XMLUtil::SetBool(const char* writeTrue, const char* writeFalse)
+{
+	static const char* defTrue = "true";
+	static const char* defFalse = "false";
+	if (writeTrue)
+		writeBoolTrue = (char*) writeTrue;
+	else
+		writeBoolTrue = (char*) defTrue;
+
+	if (writeFalse)
+		writeBoolFalse = (char*) writeFalse;
+	else
+		writeBoolFalse = (char*) defFalse;
+}
+
+
 const char* XMLUtil::ReadBOM( const char* p, bool* bom )
 {
     TIXMLASSERT( p );
@@ -545,7 +564,7 @@ void XMLUtil::ToStr( unsigned v, char* buffer, int bufferSize )
 
 void XMLUtil::ToStr( bool v, char* buffer, int bufferSize )
 {
-    TIXML_SNPRINTF( buffer, bufferSize, "%s", v ? "true" : "false" );
+    TIXML_SNPRINTF( buffer, bufferSize, "%s", v ? writeBoolTrue : writeBoolFalse);
 }
 
 /*

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -371,19 +371,13 @@ const char* StrPair::GetStr()
 const char* XMLUtil::writeBoolTrue  = "true";
 const char* XMLUtil::writeBoolFalse = "false";
 
-void XMLUtil::SetBool(const char* writeTrue, const char* writeFalse)
+void XMLUtil::SetBoolSerialization(const char* writeTrue, const char* writeFalse)
 {
-	static const char* defTrue = "true";
+	static const char* defTrue  = "true";
 	static const char* defFalse = "false";
-	if (writeTrue)
-		writeBoolTrue = writeTrue;
-	else
-		writeBoolTrue = defTrue;
 
-	if (writeFalse)
-		writeBoolFalse = writeFalse;
-	else
-		writeBoolFalse = defFalse;
+	writeBoolTrue = (writeTrue) ? writeTrue : defTrue;
+	writeBoolFalse = (writeFalse) ? writeFalse : defFalse;
 }
 
 

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -368,22 +368,22 @@ const char* StrPair::GetStr()
 
 // --------- XMLUtil ----------- //
 
-char* XMLUtil::writeBoolTrue  = "true";
-char* XMLUtil::writeBoolFalse = "false";
+const char* XMLUtil::writeBoolTrue  = "true";
+const char* XMLUtil::writeBoolFalse = "false";
 
 void XMLUtil::SetBool(const char* writeTrue, const char* writeFalse)
 {
 	static const char* defTrue = "true";
 	static const char* defFalse = "false";
 	if (writeTrue)
-		writeBoolTrue = (char*) writeTrue;
+		writeBoolTrue = writeTrue;
 	else
-		writeBoolTrue = (char*) defTrue;
+		writeBoolTrue = defTrue;
 
 	if (writeFalse)
-		writeBoolFalse = (char*) writeFalse;
+		writeBoolFalse = writeFalse;
 	else
-		writeBoolFalse = (char*) defFalse;
+		writeBoolFalse = defFalse;
 }
 
 

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -616,8 +616,8 @@ public:
 	static void SetBool(const char* writeTrue, const char* writeFalse);
 
 private:
-	static char* writeBoolTrue;
-	static char* writeBoolFalse;
+	static const char* writeBoolTrue;
+	static const char* writeBoolFalse;
 };
 
 

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -606,14 +606,12 @@ public:
     static bool ToDouble( const char* str, double* value );
 	static bool ToInt64(const char* str, int64_t* value);
 
-	// Default to "true" and "false". If you
-	// need different values, can assign them. (For instance
-	// if you need "true" to be "1".)
+	// Changes what is serialized for a boolean value.
+	// Default to "true" and "false". Shouldn't be changed
+	// unless you have a special testing or compatibility need.
 	// Be careful: static, global, & not thread safe.
 	// Be sure to set static const memory as parameters.
-	// Shouldn't be set unless you have a special reason 
-	// such as back-compatibility or testing.
-	static void SetBool(const char* writeTrue, const char* writeFalse);
+	static void SetBoolSerialization(const char* writeTrue, const char* writeFalse);
 
 private:
 	static const char* writeBoolTrue;

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -527,7 +527,7 @@ enum XMLError {
 /*
 	Utility functionality.
 */
-class XMLUtil
+class TINYXML2_LIB XMLUtil
 {
 public:
     static const char* SkipWhiteSpace( const char* p, int* curLineNumPtr )	{
@@ -605,6 +605,19 @@ public:
     static bool	ToFloat( const char* str, float* value );
     static bool ToDouble( const char* str, double* value );
 	static bool ToInt64(const char* str, int64_t* value);
+
+	// Default to "true" and "false". If you
+	// need different values, can assign them. (For instance
+	// if you need "true" to be "1".)
+	// Be careful: static, global, & not thread safe.
+	// Be sure to set static const memory as parameters.
+	// Shouldn't be set unless you have a special reason 
+	// such as back-compatibility or testing.
+	static void SetBool(const char* writeTrue, const char* writeFalse);
+
+private:
+	static char* writeBoolTrue;
+	static char* writeBoolFalse;
 };
 
 

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -757,12 +757,12 @@ int main( int argc, const char ** argv )
 			const char* result = element->Attribute("attrib");
 			XMLTest("Bool true is 'true'", "true", result);
 
-			XMLUtil::SetBool("1", "0");
+			XMLUtil::SetBoolSerialization("1", "0");
 			element->SetAttribute("attrib", true);
 			result = element->Attribute("attrib");
 			XMLTest("Bool true is '1'", "1", result);
 
-			XMLUtil::SetBool(0, 0);
+			XMLUtil::SetBoolSerialization(0, 0);
 		}
 		{
 			element->SetAttribute("attrib", 100.0);

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -753,6 +753,18 @@ int main( int argc, const char ** argv )
 			XMLTest("Attribute: bool", true, element->BoolAttribute("attrib"), true);
 		}
 		{
+			element->SetAttribute("attrib", true);
+			const char* result = element->Attribute("attrib");
+			XMLTest("Bool true is 'true'", "true", result);
+
+			XMLUtil::SetBool("1", "0");
+			element->SetAttribute("attrib", true);
+			result = element->Attribute("attrib");
+			XMLTest("Bool true is '1'", "1", result);
+
+			XMLUtil::SetBool(0, 0);
+		}
+		{
 			element->SetAttribute("attrib", 100.0);
 			double v = 0;
 			element->QueryDoubleAttribute("attrib", &v);


### PR DESCRIPTION
Allow the string for boolean serialization to be set, so you can write "1"/"0" instead of "true"/"false", etc. Addresses #507 

