### PR TITLE
Refactor test resources: Use CMake to replace mkdir()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,11 @@ else(BUILD_STATIC_LIBS)
    target_link_libraries(xmltest tinyxml2_static)
 endif()
 
-# Copy test resources
+# Copy test resources and create test output directory
 add_custom_command(TARGET xmltest POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/resources
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/resources/out
+  COMMENT "Configuring xmltest resources directory: ${CMAKE_BINARY_DIR}/resources"
 )
 
 install(FILES tinyxml2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,8 @@ endif()
 
 # Copy test resources and create test output directory
 add_custom_command(TARGET xmltest POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/resources
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/resources/out
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/resources $<TARGET_FILE_DIR:xmltest>/resources
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:xmltest>/resources/out
   COMMENT "Configuring xmltest resources directory: ${CMAKE_BINARY_DIR}/resources"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,25 +30,6 @@ set(GENERIC_LIB_SOVERSION "4")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/.")
 
 ################################
-# Add custom target to copy all data
-
-set(TARGET_DATA_COPY DATA_COPY)
-set(DATA_COPY_FILES)
-if(NOT ${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
-	foreach(data dream.xml empty.xml utf8test.xml utf8testverify.xml)
-		set(DATA_COPY_SRC  ${CMAKE_CURRENT_SOURCE_DIR}/resources/${data})
-		set(DATA_COPY_DEST ${CMAKE_CURRENT_BINARY_DIR}/resources/${data})
-		add_custom_command(
-			OUTPUT ${DATA_COPY_DEST}
-			COMMAND ${CMAKE_COMMAND}
-			ARGS -E copy ${DATA_COPY_SRC} ${DATA_COPY_DEST}
-			DEPENDS ${DATA_COPY_SRC})
-		list(APPEND DATA_COPY_FILES ${DATA_COPY_DEST})
-	endforeach(data)
-endif(NOT ${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
-add_custom_target(${TARGET_DATA_COPY} DEPENDS ${DATA_COPY_FILES})
-
-################################
 # Add definitions
 
 if(MSVC)
@@ -109,13 +90,16 @@ endif()
 add_executable(xmltest xmltest.cpp)
 if(BUILD_SHARED_LIBS)
    add_dependencies(xmltest tinyxml2)
-   add_dependencies(xmltest ${TARGET_DATA_COPY})
    target_link_libraries(xmltest tinyxml2)
 else(BUILD_STATIC_LIBS)
    add_dependencies(xmltest tinyxml2_static)
-   add_dependencies(xmltest ${TARGET_DATA_COPY})
    target_link_libraries(xmltest tinyxml2_static)
 endif()
+
+# Copy test resources
+add_custom_command(TARGET xmltest POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/resources ${CMAKE_BINARY_DIR}/resources
+)
 
 install(FILES tinyxml2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,6 @@ else(BUILD_STATIC_LIBS)
    add_dependencies(xmltest ${TARGET_DATA_COPY})
    target_link_libraries(xmltest tinyxml2_static)
 endif()
-install(TARGETS DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(FILES tinyxml2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,5 +3,5 @@ before_build:
 
 build_script:
   - msbuild tinyxml2.sln /m /p:Configuration=Release /t:ALL_BUILD
-  - copy Release\xmltest.exe .\ && copy Release\tinyxml2.dll .\
+  - cd Release
   - xmltest.exe

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -10,16 +10,10 @@
 #include <ctime>
 
 #if defined( _MSC_VER )
-	#include <direct.h>		// _mkdir
 	#include <crtdbg.h>
 	#define WIN32_LEAN_AND_MEAN
 	#include <windows.h>
 	_CrtMemState startMemState;
-	_CrtMemState endMemState;
-#elif defined(MINGW32) || defined(__MINGW32__)
-    #include <io.h>  // mkdir
-#else
-	#include <sys/stat.h>	// mkdir
 #endif
 
 using namespace tinyxml2;
@@ -297,17 +291,6 @@ int main( int argc, const char ** argv )
 		_CrtMemCheckpoint( &startMemState );
 		// Enable MS Visual C++ debug heap memory leaks dump on exit
 		_CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) | _CRTDBG_LEAK_CHECK_DF);
-	#endif
-
-	#if defined(_MSC_VER) || defined(MINGW32) || defined(__MINGW32__)
-		#if defined __MINGW64_VERSION_MAJOR && defined __MINGW64_VERSION_MINOR
-			//MINGW64: both 32 and 64-bit
-			mkdir( "resources/out/" );
-                #else
-                	_mkdir( "resources/out/" );
-                #endif
-	#else
-		mkdir( "resources/out/", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 	#endif
 
 	{


### PR DESCRIPTION
In order to to make xmltest a little more cross platform friendly, this PR replaces the calls to `mkdir()` with CMake commands to create the test output directory