### PR TITLE
Clearer variable name

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1956,12 +1956,12 @@ const char* XMLDocument::_errorNames[XML_ERROR_COUNT] = {
 };
 
 
-XMLDocument::XMLDocument( bool processEntities, Whitespace whitespace ) :
+XMLDocument::XMLDocument( bool processEntities, Whitespace whitespaceMode ) :
     XMLNode( 0 ),
     _writeBOM( false ),
     _processEntities( processEntities ),
     _errorID(XML_SUCCESS),
-    _whitespace( whitespace ),
+    _whitespaceMode( whitespaceMode ),
     _errorLineNum( 0 ),
     _charBuffer( 0 ),
     _parseCurLineNum( 0 )

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1613,7 +1613,7 @@ class TINYXML2_LIB XMLDocument : public XMLNode
     friend class XMLElement;
 public:
     /// constructor
-    XMLDocument( bool processEntities = true, Whitespace = PRESERVE_WHITESPACE );
+    XMLDocument( bool processEntities = true, Whitespace whitespaceMode = PRESERVE_WHITESPACE );
     ~XMLDocument();
 
     virtual XMLDocument* ToDocument()				{
@@ -1677,7 +1677,7 @@ public:
         return _processEntities;
     }
     Whitespace WhitespaceMode() const	{
-        return _whitespace;
+        return _whitespaceMode;
     }
 
     /**
@@ -1815,7 +1815,7 @@ private:
     bool			_writeBOM;
     bool			_processEntities;
     XMLError		_errorID;
-    Whitespace		_whitespace;
+    Whitespace		_whitespaceMode;
     mutable StrPair	_errorStr1;
     mutable StrPair	_errorStr2;
     int             _errorLineNum;


### PR DESCRIPTION
Currently the variable name for whitespace mode is rather unclear. The constructor also lacks parameter name.