### PR TITLE
Suppress C6011 code analysis false positive warning

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1838,6 +1838,7 @@ XMLAttribute* XMLElement::CreateAttribute()
 {
     TIXMLASSERT( sizeof( XMLAttribute ) == _document->_attributePool.ItemSize() );
     XMLAttribute* attrib = new (_document->_attributePool.Alloc() ) XMLAttribute();
+    TIXMLASSERT( attrib );
     attrib->_memPool = &_document->_attributePool;
     attrib->_memPool->SetTracked();
     return attrib;


### PR DESCRIPTION
C6011 is "derefencing potentially null pointer". This never actually happens and so it's a false positive from Visual Studio code analysis. The warning is emitted on the line that assigns `_memPool` member. Assertion suppresses the warning and makes code behavior clearer.