### PR TITLE
Change XMLElement::GetText() return

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1534,7 +1534,7 @@ const char* XMLElement::GetText() const
     if ( FirstChild() && FirstChild()->ToText() ) {
         return FirstChild()->Value();
     }
-    return 0;
+    return "";
 }
 
 

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -651,7 +651,7 @@ int main( int argc, const char ** argv )
 		doc.Parse( str );
 		element = doc.RootElement();
 
-		XMLTest( "GetText() contained element.", element->GetText() == 0, true );
+		XMLTest( "GetText() contained element.", !strcmp(element->GetText(), ""), true );
 	}
 
 


### PR DESCRIPTION
Hi @leethomason,
I suggest to change the XMLElement::GetText() return when no text is found from null string instead of null empty string.
I have also updated unit test accordingly.

I don't know if it is what you had in mind, but since it is a const char* I rather have the default value as an empty string that a null string but it is just a convention.