### PR TITLE
Pointer assertion

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1133,6 +1133,7 @@ XMLNode* XMLText::ShallowClone( XMLDocument* doc ) const
 
 bool XMLText::ShallowEqual( const XMLNode* compare ) const
 {
+    TIXMLASSERT( compare );
     const XMLText* text = compare->ToText();
     return ( text && XMLUtil::StringEqual( text->Value(), Value() ) );
 }


### PR DESCRIPTION
Other `ShallowEqual` methods already have such assertion.