### PR TITLE
Fully use enum

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1449,7 +1449,7 @@ void XMLAttribute::SetAttribute( float v )
 
 // --------- XMLElement ---------- //
 XMLElement::XMLElement( XMLDocument* doc ) : XMLNode( doc ),
-    _closingType( 0 ),
+    _closingType( OPEN ),
     _rootAttribute( 0 )
 {
 }
@@ -1868,7 +1868,7 @@ char* XMLElement::ParseDeep( char* p, StrPair* strPair, int* curLineNumPtr )
     }
 
     p = ParseAttributes( p, curLineNumPtr );
-    if ( !p || !*p || _closingType ) {
+    if ( !p || !*p || _closingType != OPEN ) {
         return p;
     }
 

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1559,12 +1559,12 @@ public:
 	float FloatText(float defaultValue = 0) const;
 
     // internal:
-    enum {
+    enum ElementClosingType {
         OPEN,		// <foo>
         CLOSED,		// <foo/>
         CLOSING		// </foo>
     };
-    int ClosingType() const {
+    ElementClosingType ClosingType() const {
         return _closingType;
     }
     virtual XMLNode* ShallowClone( XMLDocument* document ) const;
@@ -1589,7 +1589,7 @@ private:
     XMLAttribute* CreateAttribute();
 
     enum { BUF_SIZE = 200 };
-    int _closingType;
+    ElementClosingType _closingType;
     // The attribute list is ordered; there is no 'lastAttribute'
     // because the list needs to be scanned for dupes before adding
     // a new attribute.


### PR DESCRIPTION
Current code uses `int` instead of enum. This brings no advantages and reduces readability and type safety.