### PR TITLE
Ensure no overrun before copying

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -284,6 +284,7 @@ private:
             TIXMLASSERT( cap <= INT_MAX / 2 );
             int newAllocated = cap * 2;
             T* newMem = new T[newAllocated];
+            TIXMLASSERT( newAllocated >= _size );
             memcpy( newMem, _mem, sizeof(T)*_size );	// warning: not using constructors, only works for PODs
             if ( _mem != _pool ) {
                 delete [] _mem;


### PR DESCRIPTION
This literally checks that we actually have the target large enough to contain all the stuff being copied. Just in case.