### PR TITLE
DON'T MERGE YET Change verbosity to minimal

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,6 @@ before_build:
   - cmake .
 
 build_script:
-  - msbuild tinyxml2.sln /m /p:Configuration=Release /t:ALL_BUILD
+  - msbuild tinyxml2.sln /consoleloggerparameters:Verbosity=diagnostic /m /p:Configuration=Release /t:Build
   - cd Release
   - xmltest.exe


### PR DESCRIPTION
This should be merged for a while. I'm toying with the settings


Current Appveyor logs are rather noisy - especially the following thing being output all the time is annoying:

    The target "_ConvertPdbFiles" listed in a BeforeTargets attribute at "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets (45,37)" does not exist in the project, and will be ignored.
