### PR TITLE
Better parameter name

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -772,13 +772,13 @@ void XMLNode::SetValue( const char* str, bool staticMem )
     }
 }
 
-XMLNode* XMLNode::DeepClone(XMLDocument* document) const
+XMLNode* XMLNode::DeepClone(XMLDocument* target) const
 {
-	XMLNode* clone = this->ShallowClone(document);
+	XMLNode* clone = this->ShallowClone(target);
 	if (!clone) return 0;
 
 	for (const XMLNode* child = this->FirstChild(); child; child = child->NextSibling()) {
-		XMLNode* childClone = child->DeepClone(document);
+		XMLNode* childClone = child->DeepClone(target);
 		TIXMLASSERT(childClone);
 		clone->InsertEndChild(childClone);
 	}

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -868,8 +868,8 @@ public:
 	/**
 		Make a copy of this node and all its children.
 
-		If the 'document' is null, then the nodes will
-		be allocated in the current document. If document 
+		If the 'target' is null, then the nodes will
+		be allocated in the current document. If 'target' 
         is specified, the memory will be allocated is the 
         specified XMLDocument.
 
@@ -878,7 +878,7 @@ public:
 		top level XMLNodes. You probably want to use
         XMLDocument::DeepCopy()
 	*/
-	XMLNode* DeepClone( XMLDocument* document ) const;
+	XMLNode* DeepClone( XMLDocument* target ) const;
 
     /**
     	Test if 2 nodes are the same, but don't test children.


### PR DESCRIPTION
Current parameter name just restates it's a document (which we already know because it's of type "document").