### PR TITLE
Check result of Parse() call

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -362,6 +362,7 @@ int main( int argc, const char ** argv )
 		for( int i=0; test[i]; ++i ) {
 			XMLDocument doc;
 			doc.Parse( test[i] );
+			XMLTest( "Element test", false, doc.Error() );
 			doc.Print();
 			printf( "----------------------------------------------\n" );
 		}
@@ -376,6 +377,7 @@ int main( int argc, const char ** argv )
 
 		XMLDocument doc;
 		doc.Parse( test );
+		XMLTest( "Hello world declaration", false, doc.Error() );
 		doc.Print();
 	}
 
@@ -383,6 +385,7 @@ int main( int argc, const char ** argv )
 		static const char* test = "<element>Text before.</element>";
 		XMLDocument doc;
 		doc.Parse( test );
+		XMLTest( "Element text before", false, doc.Error() );
 		XMLElement* root = doc.FirstChildElement();
 		XMLElement* newElement = doc.NewElement( "Subelement" );
 		root->InsertEndChild( newElement );
@@ -392,6 +395,7 @@ int main( int argc, const char ** argv )
 		XMLDocument* doc = new XMLDocument();
 		static const char* test = "<element><sub/></element>";
 		doc->Parse( test );
+		XMLTest( "Element with sub element", false, doc->Error() );
 		delete doc;
 	}
 	{
@@ -507,6 +511,7 @@ int main( int argc, const char ** argv )
 
 		XMLDocument doc;
 		doc.Parse( str );
+		XMLTest( "Top level attributes", false, doc.Error() );
 
 		XMLElement* ele = doc.FirstChildElement();
 
@@ -542,6 +547,7 @@ int main( int argc, const char ** argv )
 
 		XMLDocument doc;
 		doc.Parse( str );
+		XMLTest( "Empty top element", false, doc.Error() );
 
 		XMLElement* ele = doc.FirstChildElement();
 
@@ -632,12 +638,14 @@ int main( int argc, const char ** argv )
 		const char* str = "<foo>This is  text</foo>";
 		XMLDocument doc;
 		doc.Parse( str );
+		XMLTest( "Double whitespace", false, doc.Error() );
 		const XMLElement* element = doc.RootElement();
 
 		XMLTest( "GetText() normal use.", "This is  text", element->GetText() );
 
 		str = "<foo><b>This is text</b></foo>";
 		doc.Parse( str );
+		XMLTest( "Bold text simulation", false, doc.Error() );
 		element = doc.RootElement();
 
 		XMLTest( "GetText() contained element.", element->GetText() == 0, true );
@@ -649,6 +657,7 @@ int main( int argc, const char ** argv )
 		const char* str = "<foo></foo>";
 		XMLDocument doc;
 		doc.Parse( str );
+		XMLTest( "Empty closed element", false, doc.Error() );
 		XMLElement* element = doc.RootElement();
 
 		element->SetText("darkness.");
@@ -659,6 +668,7 @@ int main( int argc, const char ** argv )
 
 		str = "<foo/>";
 		doc.Parse( str );
+		XMLTest( "Empty self-closed element", false, doc.Error() );
 		element = doc.RootElement();
 
 		element->SetText("The driver");
@@ -670,6 +680,7 @@ int main( int argc, const char ** argv )
 
 		str = "<foo><bar>Text in nested element</bar></foo>";
 		doc.Parse( str );
+		XMLTest( "Text in nested element", false, doc.Error() );
 		element = doc.RootElement();
 		
 		element->SetText("wolves");
@@ -677,6 +688,7 @@ int main( int argc, const char ** argv )
 
 		str = "<foo/>";
 		doc.Parse( str );
+		XMLTest( "Empty self-closed element round 2", false, doc.Error() );
 		element = doc.RootElement();
 		
 		element->SetText( "str" );
@@ -828,6 +840,7 @@ int main( int argc, const char ** argv )
 							"</xmlElement>";
 		XMLDocument doc;
 		doc.Parse( str );
+		XMLTest( "CDATA symbolic puns round 1", false, doc.Error() );
 		doc.Print();
 
 		XMLTest( "CDATA parse.", "I am > the rules!\n...since I make symbolic puns",
@@ -845,6 +858,7 @@ int main( int argc, const char ** argv )
 							"</xmlElement>";
 		XMLDocument doc;
 		doc.Parse( str );
+		XMLTest( "CDATA symbolic puns round 2", false, doc.Error() );
 		doc.Print();
 
 		XMLTest( "CDATA parse. [ tixml1:1480107 ]",
@@ -882,6 +896,7 @@ int main( int argc, const char ** argv )
 
 		XMLDocument doc;
 		doc.Parse( passages );
+		XMLTest( "Entity transformation parse round 1", false, doc.Error() );
 		XMLElement* psg = doc.RootElement()->FirstChildElement();
 		const char* context = psg->Attribute( "context" );
 		const char* expected = "Line 5 has \"quotation marks\" and 'apostrophe marks'. It also has <, >, and &, as well as a fake copyright \xC2\xA9.";
@@ -920,6 +935,7 @@ int main( int argc, const char ** argv )
 
 		XMLDocument doc( false );
 		doc.Parse( passages );
+		XMLTest( "Entity transformation parse round 2", false, doc.Error() );
 
 		XMLTest( "No entity parsing.",
 				 "Line 5 has &quot;quotation marks&quot; and &apos;apostrophe marks&apos;.",
@@ -944,6 +960,7 @@ int main( int argc, const char ** argv )
 
 		XMLDocument doc;
 		doc.Parse( test );
+		XMLTest( "fin thickness", false, doc.Error() );
 
 		XMLText* text = doc.FirstChildElement()->FirstChildElement()->FirstChild()->ToText();
 		XMLTest( "Entity with one digit.",
@@ -963,9 +980,12 @@ int main( int argc, const char ** argv )
 
 		XMLDocument doc;
 		doc.Parse( doctype );
+		XMLTest( "PLAY SYSTEM parse", false, doc.Error() );
 		doc.SaveFile( "resources/out/test7.xml" );
+		XMLTest( "PLAY SYSTEM save", false, doc.Error() );
 		doc.DeleteChild( doc.RootElement() );
 		doc.LoadFile( "resources/out/test7.xml" );
+		XMLTest( "PLAY SYSTEM load", false, doc.Error() );
 		doc.Print();
 
 		const XMLUnknown* decl = doc.FirstChild()->NextSibling()->ToUnknown();
@@ -979,6 +999,7 @@ int main( int argc, const char ** argv )
 			"<!-- Somewhat<evil> -->";
 		XMLDocument doc;
 		doc.Parse( doctype );
+		XMLTest( "Comment somewhat evil", false, doc.Error() );
 
 		XMLComment* comment = doc.FirstChild()->ToComment();
 
@@ -1024,6 +1045,7 @@ int main( int argc, const char ** argv )
 		// Low entities
 		XMLDocument doc;
 		doc.Parse( "<test>&#x0e;</test>" );
+		XMLTest( "Hex values", false, doc.Error() );
 		const char result[] = { 0x0e, 0 };
 		XMLTest( "Low entities.", result, doc.FirstChildElement()->GetText() );
 		doc.Print();
@@ -1053,6 +1075,7 @@ int main( int argc, const char ** argv )
 		XMLDocument xml;
 		xml.Parse("<!-- declarations for <head> & <body> -->"
 				  "<!-- far &amp; away -->" );
+		XMLTest( "Declarations for head and body", false, xml.Error() );
 
 		XMLNode* e0 = xml.FirstChild();
 		XMLNode* e1 = e0->NextSibling();
@@ -1070,6 +1093,7 @@ int main( int argc, const char ** argv )
 						"<!-- With this comment, child2 will not be parsed! -->"
 						"<child2 att=''/>"
 					"</Parent>" );
+		XMLTest( "Comments iteration", false, xml.Error() );
 		xml.Print();
 
 		int count = 0;
@@ -1092,6 +1116,7 @@ int main( int argc, const char ** argv )
 
 		XMLDocument doc;
 		doc.Parse( (const char*)buf);
+		XMLTest( "Broken CDATA", true, doc.Error() );
 	}
 
 
@@ -1107,6 +1132,7 @@ int main( int argc, const char ** argv )
 		// This one must not result in an infinite loop
 		XMLDocument xml;
 		xml.Parse( "<infinite>loop" );
+		XMLTest( "No closing element", true, xml.Error() );
 		XMLTest( "Infinite loop test.", true, true );
 	}
 #endif
@@ -1114,6 +1140,7 @@ int main( int argc, const char ** argv )
 		const char* pub = "<?xml version='1.0'?> <element><sub/></element> <!--comment--> <!DOCTYPE>";
 		XMLDocument doc;
 		doc.Parse( pub );
+		XMLTest( "Trailing DOCTYPE", false, doc.Error() );
 
 		XMLDocument clone;
 		for( const XMLNode* node=doc.FirstChild(); node; node=node->NextSibling() ) {
@@ -1147,6 +1174,7 @@ int main( int argc, const char ** argv )
 				"</root>";
 			XMLDocument doc;
 			doc.Parse(xml);
+			XMLTest( "Parse before deep cloning root element", false, doc.Error() );
 
 			doc.Print(&printer1);
 			XMLNode* root = doc.RootElement()->DeepClone(&doc2);
@@ -1173,6 +1201,7 @@ int main( int argc, const char ** argv )
 				"</root>";
 			XMLDocument doc;
 			doc.Parse(xml);
+			XMLTest( "Parse before deep cloning sub element", false, doc.Error() );
 
 			const XMLElement* subElement = doc.FirstChildElement("root")->FirstChildElement("child2");
 			subElement->Accept(&printer1);
@@ -1202,6 +1231,7 @@ int main( int argc, const char ** argv )
 				"</root>";
 			XMLDocument doc;
 			doc.Parse(xml);
+			XMLTest( "Parse before deep cloning document", false, doc.Error() );
 			doc.Print(&printer1);
 
 			doc.DeepCopy(&doc2);
@@ -1228,6 +1258,7 @@ int main( int argc, const char ** argv )
 		static const char* xml = "<element attrib1=\"1\" attrib2=\"2\" attrib3=\"3\" />";
 		XMLDocument doc;
 		doc.Parse( xml );
+		XMLTest( "Parse for attribute ordering", false, doc.Error() );
 		XMLElement* ele = doc.FirstChildElement();
 
 		const XMLAttribute* a = ele->FirstAttribute();
@@ -1256,10 +1287,13 @@ int main( int argc, const char ** argv )
 		static const char* xml2 = "<element attribute1 = \"Test Attribute\"/>";
 		XMLDocument doc0;
 		doc0.Parse( xml0 );
+		XMLTest( "Parse attribute with space 1", false, doc0.Error() );
 		XMLDocument doc1;
 		doc1.Parse( xml1 );
+		XMLTest( "Parse attribute with space 2", false, doc1.Error() );
 		XMLDocument doc2;
 		doc2.Parse( xml2 );
+		XMLTest( "Parse attribute with space 3", false, doc2.Error() );
 
 		XMLElement* ele = 0;
 		ele = doc0.FirstChildElement();
@@ -1275,6 +1309,7 @@ int main( int argc, const char ** argv )
 		static const char* xml = "<doc><element attribute='attribute'/><element attribute='attribute'/></doc>";
 		XMLDocument doc;
 		doc.Parse( xml );
+		XMLTest( "Parse two elements with attribute", false, doc.Error() );
 		XMLElement* ele0 = doc.FirstChildElement()->FirstChildElement();
 		XMLElement* ele1 = ele0->NextSiblingElement();
 		bool equal = ele0->ShallowEqual( ele1 );
@@ -1287,6 +1322,7 @@ int main( int argc, const char ** argv )
 		static const char* xml = "<element attrib='bar'><sub>Text</sub></element>";
 		XMLDocument doc;
 		doc.Parse( xml );
+		XMLTest( "Parse element with attribute and nested element round 1", false, doc.Error() );
 
 		XMLElement* ele = XMLHandle( doc ).FirstChildElement( "element" ).FirstChild().ToElement();
 		XMLTest( "Handle, success, mutable", "sub", ele->Value() );
@@ -1300,6 +1336,7 @@ int main( int argc, const char ** argv )
 		static const char* xml = "<element attrib='bar'><sub>Text</sub></element>";
 		XMLDocument doc;
 		doc.Parse( xml );
+		XMLTest( "Parse element with attribute and nested element round 2", false, doc.Error() );
 		XMLConstHandle docH( doc );
 
 		const XMLElement* ele = docH.FirstChildElement( "element" ).FirstChild().ToElement();
@@ -1333,6 +1370,7 @@ int main( int argc, const char ** argv )
 		const char* xml = "<point> <x>1.2</x> <y>1</y> <z>38</z> <valid>true</valid> </point>";
 		XMLDocument doc;
 		doc.Parse( xml );
+		XMLTest( "Parse points", false, doc.Error() );
 
 		const XMLElement* pointElement = doc.RootElement();
 
@@ -1404,6 +1442,7 @@ int main( int argc, const char ** argv )
 						  "</element>";
 		XMLDocument doc( true, COLLAPSE_WHITESPACE );
 		doc.Parse( xml );
+		XMLTest( "Parse with whitespace collapsing and &apos", false, doc.Error() );
 
 		const XMLElement* element = doc.FirstChildElement();
 		for( const XMLElement* parent = element->FirstChildElement();
@@ -1431,6 +1470,7 @@ int main( int argc, const char ** argv )
 		const char* xml = "<element>    </element>";
 		XMLDocument doc( true, COLLAPSE_WHITESPACE );
 		doc.Parse( xml );
+		XMLTest( "Parse with all whitespaces", false, doc.Error() );
 		XMLTest( "Whitespace  all space", true, 0 == doc.FirstChildElement()->FirstChild() );
 	}
 
@@ -1439,6 +1479,7 @@ int main( int argc, const char ** argv )
 		const char* xml = "<element/>";
 		XMLDocument doc;
 		doc.Parse( xml );
+		XMLTest( "Parse with self-closed element", false, doc.Error() );
 		XMLElement* ele = doc.NewElement( "unused" );		// This will get cleaned up with the 'doc' going out of scope.
 		XMLTest( "Tracking unused elements", true, ele != 0, false );
 	}
@@ -1448,6 +1489,7 @@ int main( int argc, const char ** argv )
 		const char* xml = "<parent><child>abc</child></parent>";
 		XMLDocument doc;
 		doc.Parse( xml );
+		XMLTest( "Parse for printing of sub-element", false, doc.Error() );
 		XMLElement* ele = doc.FirstChildElement( "parent")->FirstChildElement( "child");
 
 		XMLPrinter printer;
@@ -1526,6 +1568,7 @@ int main( int argc, const char ** argv )
 
 		XMLDocument doc;
 		doc.Parse(xml);
+		XMLTest( "Insertion with removal parse round 1", false, doc.Error() );
 		XMLElement* subtree = doc.RootElement()->FirstChildElement("one")->FirstChildElement("subtree");
 		XMLElement* two = doc.RootElement()->FirstChildElement("two");
 		two->InsertFirstChild(subtree);
@@ -1534,6 +1577,7 @@ int main( int argc, const char ** argv )
 		XMLTest("Move node from within <one> to <two>", xmlInsideTwo, printer1.CStr());
 
 		doc.Parse(xml);
+		XMLTest( "Insertion with removal parse round 2", false, doc.Error() );
 		subtree = doc.RootElement()->FirstChildElement("one")->FirstChildElement("subtree");
 		two = doc.RootElement()->FirstChildElement("two");
 		doc.RootElement()->InsertAfterChild(two, subtree);
@@ -1542,6 +1586,7 @@ int main( int argc, const char ** argv )
 		XMLTest("Move node from within <one> after <two>", xmlAfterTwo, printer2.CStr(), false);
 
 		doc.Parse(xml);
+		XMLTest( "Insertion with removal parse round 3", false, doc.Error() );
 		XMLNode* one = doc.RootElement()->FirstChildElement("one");
 		subtree = one->FirstChildElement("subtree");
 		doc.RootElement()->InsertAfterChild(one, subtree);
@@ -1550,6 +1595,7 @@ int main( int argc, const char ** argv )
 		XMLTest("Move node from within <one> after <one>", xmlAfterOne, printer3.CStr(), false);
 
 		doc.Parse(xml);
+		XMLTest( "Insertion with removal parse round 4", false, doc.Error() );
 		subtree = doc.RootElement()->FirstChildElement("one")->FirstChildElement("subtree");
 		two = doc.RootElement()->FirstChildElement("two");
 		doc.RootElement()->InsertEndChild(subtree);
@@ -1564,6 +1610,7 @@ int main( int argc, const char ** argv )
 			"</svg>";
 		XMLDocument doc;
 		doc.Parse(xml);
+		XMLTest( "Parse svg with text", false, doc.Error() );
 		doc.Print();
 	}
 
@@ -1572,6 +1619,7 @@ int main( int argc, const char ** argv )
 		const char* xml = "<?xml version=\"1.0\"?><root><sample><field0><1</field0><field1>2</field1></sample></root>";
 		XMLDocument doc;
 		doc.Parse(xml);
+		XMLTest( "Parse root-sample-field0", true, doc.Error() );
 		doc.PrintError();
 	}
 
@@ -1583,6 +1631,7 @@ int main( int argc, const char ** argv )
 		const char* xml = "<element/>";
 		XMLDocument doc;
 		doc.Parse( xml );
+		XMLTest( "Parse self-closed empty element", false, doc.Error() );
 		doc.FirstChildElement()->SetAttribute( "attrA-f64", 123456789.123456789 );
 		doc.FirstChildElement()->SetAttribute( "attrB-f64", 1.001e9 );
 		doc.FirstChildElement()->SetAttribute( "attrC-f64", 1.0e9 );
@@ -1619,10 +1668,12 @@ int main( int argc, const char ** argv )
         {
             XMLDocument doc;
             doc.Parse(xmlText);
+            XMLTest( "Parse hex no closing tag round 1", true, doc.Error() );
         }
         {
             XMLDocument doc;
             doc.Parse(xmlText);
+            XMLTest( "Parse hex no closing tag round 2", true, doc.Error() );
             doc.Clear();
         }
     }
@@ -1644,6 +1695,7 @@ int main( int argc, const char ** argv )
 		const char* xml = "&#0</a>";
 		XMLDocument doc;
 		doc.Parse( xml );
+		XMLTest( "Parse hex with closing tag", false, doc.Error() );
 
 		XMLPrinter printer;
 		doc.Print( &printer );
@@ -1717,6 +1769,7 @@ int main( int argc, const char ** argv )
 	    XMLDocument* doc = new XMLDocument();
 	    XMLTest( "XMLDocument::Value() returns null?", NULL, doc->Value() );
 	    doc->Parse( validXml );
+	    XMLTest( "Parse to test XMLDocument::Value()", false, doc->Error());
 	    XMLTest( "XMLDocument::Value() returns null?", NULL, doc->Value() );
 	    delete doc;
     }
@@ -1961,11 +2014,14 @@ int main( int argc, const char ** argv )
 #else
 		clock_t cstart = clock();
 #endif
+		bool parseDreamXmlFailed = false;
 		static const int COUNT = 10;
 		for (int i = 0; i < COUNT; ++i) {
 			XMLDocument doc;
 			doc.Parse(mem);
+			parseDreamXmlFailed = parseDreamXmlFailed || doc.Error();
 		}
+		XMLTest( "Parse dream.xml", false, parseDreamXmlFailed );
 #if defined( _MSC_VER )
 		QueryPerformanceCounter((LARGE_INTEGER*)&end);
 #else


### PR DESCRIPTION
Current code fails to check result of `XMLDocument.Parse()` in many cases.