### PR TITLE
Clarify and simplify test output

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -2112,10 +2112,11 @@ int main( int argc, const char ** argv )
 #endif
 
 #if defined( _MSC_VER )
-		printf("\nParsing %s of dream.xml: %.3f milli-seconds\n", note, 1000.0 * (double)(end - start) / ((double)freq * (double)COUNT));
+		const double duration = 1000.0 * (double)(end - start) / ((double)freq * (double)COUNT);
 #else
-		printf("\nParsing %s of dream.xml: %.3f milli-seconds\n", note, (double)(cend - cstart) / (double)COUNT);
+		const double duration = (double)(cend - cstart) / (double)COUNT;
 #endif
+		printf("\nParsing dream.xml (%s): %.3f milli-seconds\n", note, duration);
 	}
 
 	#if defined( _MSC_VER ) &&  defined( DEBUG )


### PR DESCRIPTION
Current code produces output that looks like this:

    Parsing Release of dream.xml: 1.799 milli-seconds

which reads "parsing release of something" which isn't very clear. Also current code has output duplicated in the code.