### PR TITLE
Cleanup stream mode tests

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -881,7 +881,8 @@ int main( int argc, const char ** argv )
 	// ---------- XMLPrinter stream mode ------
 	{
 		{
-			FILE* printerfp = fopen("resources/printer.xml", "w");
+			FILE* printerfp = fopen("resources/out/printer.xml", "w");
+			XMLTest("Open printer.xml", true, printerfp != 0);
 			XMLPrinter printer(printerfp);
 			printer.OpenElement("foo");
 			printer.PushAttribute("attrib-text", "text");
@@ -895,7 +896,7 @@ int main( int argc, const char ** argv )
 		}
 		{
 			XMLDocument doc;
-			doc.LoadFile("resources/printer.xml");
+			doc.LoadFile("resources/out/printer.xml");
 			XMLTest("XMLPrinter Stream mode: load", XML_SUCCESS, doc.ErrorID(), true);
 
 			const XMLDocument& cdoc = doc;


### PR DESCRIPTION
 Current code fails to use "out" subpath for the temporary file which is used for other similar tests. Also it's a good idea to test that the file was actually opened before writing - the file is later opened for reading anyway.