### PR TITLE
Test ErrorID after Parse()

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1996,10 +1996,11 @@ int main( int argc, const char ** argv )
             void TestParseError(const char *testString, const char *docStr, XMLError expected_error, int expectedLine)
             {
                 XMLDocument doc;
-                XMLError err = doc.Parse(docStr);
+                const XMLError parseError = doc.Parse(docStr);
 
+                XMLTest(testString, parseError, doc.ErrorID());
                 XMLTest(testString, true, doc.Error());
-                XMLTest(testString, expected_error, err);
+                XMLTest(testString, expected_error, parseError);
                 XMLTest(testString, expectedLine, doc.GetErrorLineNum());
             };
 


### PR DESCRIPTION
Current code only tests the return value of `Parse()`. `ErrorID()` should also be tested.