### PR TITLE
Cleanup fopen() tests

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -645,14 +645,17 @@ int main( int argc, const char ** argv )
 		XMLTest( "UTF-8: Save testout.xml", false, doc.Error() );
 
 		// Check the round trip.
-		int okay = 0;
+		bool roundTripOkay = false;
 
 		FILE* saved  = fopen( "resources/out/utf8testout.xml", "r" );
+		XMLTest( "UTF-8: Open utf8testout.xml", true, saved != 0 );
+
 		FILE* verify = fopen( "resources/utf8testverify.xml", "r" );
+		XMLTest( "UTF-8: Open utf8testverify.xml", true, verify != 0 );
 
 		if ( saved && verify )
 		{
-			okay = 1;
+			roundTripOkay = true;
 			char verifyBuf[256];
 			while ( fgets( verifyBuf, 256, verify ) )
 			{
@@ -665,7 +668,7 @@ int main( int argc, const char ** argv )
 				{
 					printf( "verify:%s<\n", verifyBuf );
 					printf( "saved :%s<\n", savedBuf );
-					okay = 0;
+					roundTripOkay = false;
 					break;
 				}
 			}
@@ -674,7 +677,7 @@ int main( int argc, const char ** argv )
 			fclose( saved );
 		if ( verify )
 			fclose( verify );
-		XMLTest( "UTF-8: Verified multi-language round trip.", 1, okay );
+		XMLTest( "UTF-8: Verified multi-language round trip.", true, roundTripOkay );
 	}
 
 	// --------GetText()-----------
@@ -993,7 +996,9 @@ int main( int argc, const char ** argv )
 
 		XMLTest( "Entity transformation: read. ", expected, context, true );
 
-		FILE* textfile = fopen( "resources/out/textfile.txt", "w" );
+		const char* textFilePath = "resources/out/textfile.txt";
+		FILE* textfile = fopen( textFilePath, "w" );
+		XMLTest( "Entity transformation: open text file for writing", true, textfile != 0, true );
 		if ( textfile )
 		{
 			XMLPrinter streamer( textfile );
@@ -1001,8 +1006,8 @@ int main( int argc, const char ** argv )
 			fclose( textfile );
 		}
 
-        textfile = fopen( "resources/out/textfile.txt", "r" );
-		TIXMLASSERT( textfile );
+		textfile = fopen( textFilePath, "r" );
+		XMLTest( "Entity transformation: open text file for reading", true, textfile != 0, true );
 		if ( textfile )
 		{
 			char buf[ 1024 ];


### PR DESCRIPTION
Current code uses `int` in place of `bool`, has the file path duplicated and sometimes fails to check `fopen()` return values.