### PR TITLE
Add 'const' on XMLDocument::DeepCopy. 

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2054,7 +2054,7 @@ void XMLDocument::Clear()
 }
 
 
-void XMLDocument::DeepCopy(XMLDocument* target)
+void XMLDocument::DeepCopy(XMLDocument* target) const
 {
 	TIXMLASSERT(target);
     if (target == this) {

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1826,7 +1826,7 @@ public:
 
 		NOTE: that the 'target' must be non-null.
 	*/
-	void DeepCopy(XMLDocument* target);
+	void DeepCopy(XMLDocument* target) const;
 
 	// internal
     char* Identify( char* p, XMLNode** node );


### PR DESCRIPTION
This make const XMLDocument be copied to another document. `make test` passes all the test.