### PR TITLE
Extract and reuse conversion code

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2380,8 +2380,9 @@ XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
     }
     for( int i=0; i<NUM_ENTITIES; ++i ) {
         const char entityValue = entities[i].value;
-        TIXMLASSERT( ((unsigned char)entityValue) < ENTITY_RANGE );
-        _entityFlag[ (unsigned char)entityValue ] = true;
+        const unsigned char flagIndex = (unsigned char)entityValue;
+        TIXMLASSERT( flagIndex < ENTITY_RANGE );
+        _entityFlag[flagIndex] = true;
     }
     _restrictedEntityFlag[(unsigned char)'&'] = true;
     _restrictedEntityFlag[(unsigned char)'<'] = true;


### PR DESCRIPTION
Current code repeatedly casts the same variable to the same type. It's unclear whether those must be identical. New code extracts and reuses the cast.