### PR TITLE
XMLPrinter optimization rebased

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2224,6 +2224,9 @@ protected:
 	*/
     virtual void PrintSpace( int depth );
     void Print( const char* format, ... );
+    void Write( const char* data, size_t size );
+    inline void Write( const char* data )           { Write( data, strlen( data ) ); }
+    void Putc( char ch );
 
     void SealElementIfJustOpened();
     bool _elementJustOpened;


### PR DESCRIPTION
I was about to look into doing this optimization myself when I noticed @algol83 had already done it in the unmerged pull request #429.

I've rebased their work against master.

My own testing shows a slightly more conservative but still substantial speed up (from 1,092 ms to 288 ms).

`XMLPrinter::Print` appears to be unused now (which surprised me). Everything can be written using memcpy or char assignment (no printf formatting needed). I think the next performance step would be to eliminate as many uses of `strlen` as possible.