### PR TITLE
cmake: resolve conflicts building both shared and static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ set_target_properties(tinyxml2_static PROPERTIES
         COMPILE_DEFINITONS "TINYXML2_EXPORT"
         VERSION "${GENERIC_LIB_VERSION}"
         SOVERSION "${GENERIC_LIB_SOVERSION}")
-set_target_properties( tinyxml2_static PROPERTIES OUTPUT_NAME tinyxml2 )
+set_target_properties( tinyxml2_static PROPERTIES OUTPUT_NAME tinyxml2_static )
 
 target_compile_definitions(tinyxml2_static PUBLIC -D_CRT_SECURE_NO_WARNINGS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 
 # export targets for find_package config mode
 export(TARGETS tinyxml2
-      APPEND FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Targets.cmake)
+      FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Targets.cmake)
 
 install(TARGETS tinyxml2
         EXPORT ${CMAKE_PROJECT_NAME}Targets
@@ -111,8 +111,13 @@ else()
 endif()
 
 # export targets for find_package config mode
-export(TARGETS tinyxml2_static
-      APPEND FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Targets.cmake)
+	if(BUILD_SHARED_LIBS) #append to *Targets.cmake
+		export(TARGETS tinyxml2_static
+				APPEND FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Targets.cmake)
+	else() #discard previous contents of *Targets.cmake
+		export(TARGETS tinyxml2_static
+				FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Targets.cmake)
+	endif()
 
 install(TARGETS tinyxml2_static
         EXPORT ${CMAKE_PROJECT_NAME}Targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 
 # export targets for find_package config mode
 export(TARGETS tinyxml2
-      FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Targets.cmake)
+      APPEND FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Targets.cmake)
 
 install(TARGETS tinyxml2
         EXPORT ${CMAKE_PROJECT_NAME}Targets
@@ -112,7 +112,7 @@ endif()
 
 # export targets for find_package config mode
 export(TARGETS tinyxml2_static
-      FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Targets.cmake)
+      APPEND FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Targets.cmake)
 
 install(TARGETS tinyxml2_static
         EXPORT ${CMAKE_PROJECT_NAME}Targets


### PR DESCRIPTION
This PR includes two changes to fix issues when using both `-DBUILD_STATIC_LIBS=ON` and (the default value) `-DBUILD_SHARED_LIBS=ON` to build the library for both static and shared linking.

## `export(TARGETS)`
The first commit changes the `export(TARGETS)` commands to append, since they both write to the same output configuration file (see https://cmake.org/cmake/help/v3.10/command/export.html , second syntax: ` If the APPEND option is given the generated code will be appended to the file instead of overwriting it.` ). Without this, only the latter target, tinyxml2_static, will be exported (for the configuration to be usable as IMPORT library from other libraries -- if I understand correctly. The effects are visible in the generated `tinyxml2Targets.cmake`).

## differentiating the static library's name
The second commit might introduce incompatibilities, but is necessary for MSVC. MSVC generates a .lib ("import library") even when creating shared (.dll) libraries. Because the name for both targets is configured to be identical (both `tinyxml2`), the second target to be built will always overwrite the first one. I guess when you build them manually you can copy the right version out if you're careful, but when building in bulk (like with the BUILD_ALL project generated by CMake's vs generator, or when using `cmake --build` mode) only one of the two files survives (and it's not even trivial to tell which one it is).

My solution for the second change was to rename the static target to `tinyxml2_static`, which makes it easier to reason about and allows choosing shared vs static with the same library search path, just by name. Since it's unnecessary for other compilers (iirc the unix/posix world uses `.a` for static and `.so` for dynamic libraries), it would also to only change its name when using MSVC, but I personally think it might add to the confusion, even if changing the naming scheme globally will lead to compatibility issues in existing build setups.

(Maybe the most liberal approach would be to hide the changed name behind another CMake option, but I think at that point we're overengineering.)