### PR TITLE
Remove unneeded conversions

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -833,10 +833,10 @@ int main( int argc, const char ** argv )
 			}
 			{
 				const char* v = "failed";
-				int queryResult = element->QueryStringAttribute("not-attrib", &v);
+				XMLError queryResult = element->QueryStringAttribute("not-attrib", &v);
 				XMLTest("Attribute: string default", false, queryResult == XML_SUCCESS);
 				queryResult = element->QueryStringAttribute("attrib", &v);
-				XMLTest("Attribute: string", (int)XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: string", XML_SUCCESS, queryResult, true);
 				XMLTest("Attribute: string", "100", v);
 			}
 			XMLTest("Attribute: unsigned", unsigned(100), element->UnsignedAttribute("attrib"), true);


### PR DESCRIPTION
No need to use `int` here - the function returns `XMLError`.