### PR TITLE
In PrintString, move the optimization under the if ( _processEntities…

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2523,14 +2523,16 @@ void XMLPrinter::PrintString( const char* p, bool restricted )
             ++q;
             TIXMLASSERT( p <= q );
         }
+        // Flush the remaining string. This will be the entire
+        // string if an entity wasn't found.
+        if ( p < q ) {
+            const size_t delta = q - p;
+            const int toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
+            Write( p, toPrint );
+        }
     }
-    // Flush the remaining string. This will be the entire
-    // string if an entity wasn't found.
-    TIXMLASSERT( p <= q );
-    if ( !_processEntities || ( p < q ) ) {
-        const size_t delta = q - p;
-        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
-        Write( p, toPrint );
+    else {
+        Write( p );
     }
 }
 

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1996,6 +1996,17 @@ int main( int argc, const char ** argv )
 	}
 
 	{
+		const char* html("<!DOCTYPE html><html><body><p>test</p><p><br/></p></body></html>");
+		XMLDocument doc(false);
+		doc.Parse(html);
+
+		XMLPrinter printer(0, true);
+		doc.Print(&printer);
+
+		XMLTest(html, html, printer.CStr());
+	}
+
+	{
 		// Evil memory leaks. 
 		// If an XMLElement (etc) is allocated via NewElement() (etc.)
 		// and NOT added to the XMLDocument, what happens?


### PR DESCRIPTION
… ) block and retain the strlen version of Write in the new else block. Added a test case from the issue #651.

Fixes issue #651.