### PR TITLE
Replace absolute installation paths with relative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ set_target_properties(tinyxml2 PROPERTIES
 if(DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
     target_include_directories(tinyxml2 PUBLIC 
                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                          $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>)
+                          $<INSTALL_INTERFACE:include>)
 
     if(MSVC)
       target_compile_definitions(tinyxml2 PUBLIC -D_CRT_SECURE_NO_WARNINGS)
@@ -97,7 +97,7 @@ target_compile_definitions(tinyxml2_static PUBLIC -D_CRT_SECURE_NO_WARNINGS)
 if(DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
     target_include_directories(tinyxml2_static PUBLIC 
                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                          $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>)
+                          $<INSTALL_INTERFACE:include>)
 
     if(MSVC)
       target_compile_definitions(tinyxml2_static PUBLIC -D_CRT_SECURE_NO_WARNINGS)
@@ -173,4 +173,4 @@ install(FILES
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME})
 
 install(EXPORT ${CMAKE_PROJECT_NAME}Targets
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME})
+        DESTINATION lib/cmake/${CMAKE_PROJECT_NAME})


### PR DESCRIPTION
As part of ruslo/hunter#1397 I would like to add TinyXML2 to the Hunter package manager.

The issue that prevents me from doing it is that some installation paths in CMakeLists.txt are specified as absolute paths and therefore the `*Config.cmake` and `*Targets.cmake` file are generated with absolute installation paths that are hardcoded into the two `.cmake` files.

For instance the installed tinyxml2Targets.cmake before the patch (with stubby `<install_prefix_absolute_path>`:
```cmake
# The installation prefix configured by this project.
set(_IMPORT_PREFIX "/<install_prefix_absolute_path>/")

# Create imported target tinyxml2
add_library(tinyxml2 SHARED IMPORTED)

set_target_properties(tinyxml2 PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "/<install_prefix_absolute_path>/include"
)

```

After the patch:
```cmake
# Compute the installation prefix relative to this file.
get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
if(_IMPORT_PREFIX STREQUAL "/")
  set(_IMPORT_PREFIX "")
endif()

# Create imported target tinyxml2
add_library(tinyxml2 SHARED IMPORTED)

set_target_properties(tinyxml2 PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
)
```

This patch makes sure that the installation of TinyXML2 can be relocated to a different directory.