### PR TITLE
Fix strlen() overflow

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -372,6 +372,23 @@ const char* StrPair::GetStr()
 const char* XMLUtil::writeBoolTrue  = "true";
 const char* XMLUtil::writeBoolFalse = "false";
 
+size_t XMLUtil::StringLen(char* p, size_t bufferSize)
+{
+    TIXMLASSERT(p);
+    TIXMLASSERT(bufferSize > 0);
+    if (!p || !bufferSize)
+        return 0;
+
+    void* end = memchr(p, 0, bufferSize);
+    if (!end) {
+        // Overflow!! Not a string. Fix it.
+        p[bufferSize-1] = 0;
+        return bufferSize - 1;
+    }
+    return end - p;
+}
+
+
 void XMLUtil::SetBoolSerialization(const char* writeTrue, const char* writeFalse)
 {
 	static const char* defTrue  = "true";
@@ -2283,7 +2300,7 @@ XMLError XMLDocument::Parse( const char* p, size_t len )
         return _errorID;
     }
     if ( len == (size_t)(-1) ) {
-        len = strlen( p );
+        len = XMLUtil::StrLen(p, len);
     }
     TIXMLASSERT( _charBuffer == 0 );
     _charBuffer = new char[ len+1 ];
@@ -2330,9 +2347,9 @@ void XMLDocument::SetError( XMLError error, int lineNum, const char* format, ...
     TIXML_SNPRINTF(buffer, BUFFER_SIZE, "Error=%s ErrorID=%d (0x%x) Line number=%d", ErrorIDToName(error), int(error), int(error), lineNum);
 
 	if (format) {
-		size_t len = strlen(buffer);
+		size_t len = XMLUtil::StrLen(buffer, BUFFER_SIZE);
 		TIXML_SNPRINTF(buffer + len, BUFFER_SIZE - len, ": ");
-		len = strlen(buffer);
+		len = XMLUtil::StrLen(buffer, BUFFER_SIZE);
 
 		va_list va;
 		va_start(va, format);

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -372,7 +372,7 @@ const char* StrPair::GetStr()
 const char* XMLUtil::writeBoolTrue  = "true";
 const char* XMLUtil::writeBoolFalse = "false";
 
-size_t XMLUtil::StringLen(char* p, size_t bufferSize)
+size_t XMLUtil::StrLen(char* p, size_t bufferSize)
 {
     TIXMLASSERT(p);
     TIXMLASSERT(bufferSize > 0);
@@ -380,12 +380,12 @@ size_t XMLUtil::StringLen(char* p, size_t bufferSize)
         return 0;
 
     void* end = memchr(p, 0, bufferSize);
+    TIXMLASSERT(end);
     if (!end) {
-        // Overflow!! Not a string. Fix it.
         p[bufferSize-1] = 0;
         return bufferSize - 1;
     }
-    return end - p;
+    return end - (void*)p;
 }
 
 

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -372,20 +372,19 @@ const char* StrPair::GetStr()
 const char* XMLUtil::writeBoolTrue  = "true";
 const char* XMLUtil::writeBoolFalse = "false";
 
-size_t XMLUtil::StrLen(char* p, size_t bufferSize)
+size_t XMLUtil::StrLen(const char* p, size_t bufferSize)
 {
     TIXMLASSERT(p);
     TIXMLASSERT(bufferSize > 0);
     if (!p || !bufferSize)
         return 0;
 
-    void* end = memchr(p, 0, bufferSize);
+    void* end = memchr((void*)p, 0, bufferSize);
     TIXMLASSERT(end);
     if (!end) {
-        p[bufferSize-1] = 0;
-        return bufferSize - 1;
+        return 0;
     }
-    return end - (void*)p;
+    return (char*)end - p;
 }
 
 

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -601,10 +601,8 @@ public:
         return strncmp( p, q, nChar ) == 0;
     }
 
-
-    // Gets the lengith of a buffer. Note this is *aggressive* safe;
-    // if there isn't a null terminator, it will add one!
-    static size_t StringLen(char* p, size_t bufferSize);
+    // Safe buffer strlen
+    static size_t StrLen(const char* p, size_t bufferSize);
 
     inline static bool IsUTF8Continuation( char p ) {
         return ( p & 0x80 ) != 0;

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -106,10 +106,10 @@ static const int TIXML2_PATCH_VERSION = 0;
 #define TINYXML2_MINOR_VERSION 2
 #define TINYXML2_PATCH_VERSION 0
 
-// A fixed element depth limit is problematic. There needs to be a 
-// limit to avoid a stack overflow. However, that limit varies per 
-// system, and the capacity of the stack. On the other hand, it's a trivial 
-// attack that can result from ill, malicious, or even correctly formed XML, 
+// A fixed element depth limit is problematic. There needs to be a
+// limit to avoid a stack overflow. However, that limit varies per
+// system, and the capacity of the stack. On the other hand, it's a trivial
+// attack that can result from ill, malicious, or even correctly formed XML,
 // so there needs to be a limit in place.
 static const int TINYXML2_MAX_ELEMENT_DEPTH = 100;
 
@@ -349,7 +349,7 @@ public:
     ~MemPoolT() {
         Clear();
     }
-    
+
     void Clear() {
         // Delete the blocks.
         while( !_blockPtrs.Empty()) {
@@ -395,7 +395,7 @@ public:
         ++_nUntracked;
         return result;
     }
-    
+
     virtual void Free( void* mem ) {
         if ( !mem ) {
             return;
@@ -572,7 +572,7 @@ public:
     static bool IsWhiteSpace( char p )					{
         return !IsUTF8Continuation(p) && isspace( static_cast<unsigned char>(p) );
     }
-    
+
     inline static bool IsNameStartChar( unsigned char ch ) {
         if ( ch >= 128 ) {
             // This is a heuristic guess in attempt to not implement Unicode-aware isalpha()
@@ -583,7 +583,7 @@ public:
         }
         return ch == ':' || ch == '_';
     }
-    
+
     inline static bool IsNameChar( unsigned char ch ) {
         return IsNameStartChar( ch )
                || isdigit( ch )
@@ -600,7 +600,12 @@ public:
         TIXMLASSERT( nChar >= 0 );
         return strncmp( p, q, nChar ) == 0;
     }
-    
+
+
+    // Gets the lengith of a buffer. Note this is *aggressive* safe;
+    // if there isn't a null terminator, it will add one!
+    static size_t StringLen(char* p, size_t bufferSize);
+
     inline static bool IsUTF8Continuation( char p ) {
         return ( p & 0x80 ) != 0;
     }
@@ -882,11 +887,11 @@ public:
 		Make a copy of this node and all its children.
 
 		If the 'target' is null, then the nodes will
-		be allocated in the current document. If 'target' 
-        is specified, the memory will be allocated is the 
+		be allocated in the current document. If 'target'
+        is specified, the memory will be allocated is the
         specified XMLDocument.
 
-		NOTE: This is probably not the correct tool to 
+		NOTE: This is probably not the correct tool to
 		copy a document, since XMLDocuments can have multiple
 		top level XMLNodes. You probably want to use
         XMLDocument::DeepCopy()
@@ -925,8 +930,8 @@ public:
     */
     virtual bool Accept( XMLVisitor* visitor ) const = 0;
 
-	/** 
-		Set user data into the XMLNode. TinyXML-2 in 
+	/**
+		Set user data into the XMLNode. TinyXML-2 in
 		no way processes or interprets user data.
 		It is initially 0.
 	*/
@@ -1384,14 +1389,14 @@ public:
 	}
 
 
-	
+
     /** Given an attribute name, QueryAttribute() returns
     	XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
     	can't be performed, or XML_NO_ATTRIBUTE if the attribute
     	doesn't exist. It is overloaded for the primitive types,
 		and is a generally more convenient replacement of
 		QueryIntAttribute() and related functions.
-		
+
 		If successful, the result of the conversion
     	will be written to 'value'. If not successful, nothing will
     	be written to 'value'. This allows you to provide default
@@ -1530,7 +1535,7 @@ public:
     	@verbatim
     		<foo>Hullaballoo!<b>This is text</b></foo>
     	@endverbatim
-		
+
 		For this XML:
     	@verbatim
     		<foo />
@@ -1544,15 +1549,15 @@ public:
     /// Convenience method for setting text inside an element. See SetText() for important limitations.
     void SetText( int value );
     /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( unsigned value );  
+    void SetText( unsigned value );
 	/// Convenience method for setting text inside an element. See SetText() for important limitations.
 	void SetText(int64_t value);
 	/// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( bool value );  
+    void SetText( bool value );
     /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( double value );  
+    void SetText( double value );
     /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( float value );  
+    void SetText( float value );
 
     /**
     	Convenience method to query the value of a child text node. This is probably best
@@ -1660,7 +1665,7 @@ class TINYXML2_LIB XMLDocument : public XMLNode
     friend class XMLElement;
     // Gives access to SetError and Push/PopDepth, but over-access for everything else.
     // Wishing C++ had "internal" scope.
-    friend class XMLNode;       
+    friend class XMLNode;
     friend class XMLText;
     friend class XMLComment;
     friend class XMLDeclaration;
@@ -1700,8 +1705,8 @@ public:
 
     /**
     	Load an XML file from disk. You are responsible
-    	for providing and closing the FILE*. 
-     
+    	for providing and closing the FILE*.
+
         NOTE: The file should be opened as binary ("rb")
         not text in order for TinyXML-2 to correctly
         do newline normalization.
@@ -1831,7 +1836,7 @@ public:
 	const char* ErrorName() const;
     static const char* ErrorIDToName(XMLError errorID);
 
-    /** Returns a "long form" error description. A hopefully helpful 
+    /** Returns a "long form" error description. A hopefully helpful
         diagnostic with location, line number, and/or additional info.
     */
 	const char* ErrorStr() const;
@@ -1844,7 +1849,7 @@ public:
     {
         return _errorLineNum;
     }
-    
+
     /// Clear the document, resetting it to the initial state.
     void Clear();
 
@@ -1907,8 +1912,8 @@ private:
 	// the stack. Track stack depth, and error out if needed.
 	class DepthTracker {
 	public:
-		DepthTracker(XMLDocument * document) { 
-			this->_document = document; 
+		DepthTracker(XMLDocument * document) {
+			this->_document = document;
 			document->PushDepth();
 		}
 		~DepthTracker() {


### PR DESCRIPTION
It's not easily fixable to address some of the deeper down calls, but the obvious points of failure can be addressed.

A bad call to the library will still crash it; the goal isn't to make TinyXML-2 immune to malicious API calls, which I suspect is the cause of the bug. However, it's also straightforward to protect against what is an unsafe method in this case.

Fix is still WIP.