### PR TITLE
Issue_706: Make resources path relative to current source and binary dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,9 @@ if(BUILD_TESTING AND BUILD_TESTS)
 
   # Copy test resources and create test output directory
   add_custom_command(TARGET xmltest POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/resources $<TARGET_FILE_DIR:xmltest>/resources
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/resources $<TARGET_FILE_DIR:xmltest>/resources
     COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:xmltest>/resources/out
-    COMMENT "Configuring xmltest resources directory: ${CMAKE_BINARY_DIR}/resources"
+    COMMENT "Configuring xmltest resources directory: ${CMAKE_CURRENT_BINARY_DIR}/resources"
   )
 
   add_test(NAME xmltest COMMAND xmltest WORKING_DIRECTORY $<TARGET_FILE_DIR:xmltest>)


### PR DESCRIPTION
Make resources folder for xml test relative to current source and binary directory. This was failing to build as a nested subrepository, where CMAKE_SOURCE_DIR pointed to a parent folder. For issue #706.