### PR TITLE
Check the element is the last child of the document

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1782,6 +1782,7 @@ int main( int argc, const char ** argv )
 		XMLTest( "Insertion with removal parse round 4", false, doc.Error() );
 		subtree = doc.RootElement()->FirstChildElement("one")->FirstChildElement("subtree");
 		two = doc.RootElement()->FirstChildElement("two");
+		XMLTest("<two> is the last child at root level", true, two == doc.RootElement()->LastChildElement());
 		doc.RootElement()->InsertEndChild(subtree);
 		XMLPrinter printer4(0, true);
 		acceptResult = doc.Accept(&printer4);


### PR DESCRIPTION
This was found with Cppcheck. `two` was not read. One option would be to just remove it but this test is basically the same as "round 2" so it's clearer to show what `two` must contain.