### PR TITLE
Fix slicing of int64_t

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -82,8 +82,15 @@ template< class T > bool XMLTest( const char* testString, T expected, T found, b
 
 	if ( !echo )
 		printf (" %s\n", testString);
-	else
-		printf (" %s [%d][%d]\n", testString, static_cast<int>(expected), static_cast<int>(found) );
+	else {
+		char expectedAsString[64];
+		XMLUtil::ToStr(expected, expectedAsString, sizeof(expectedAsString));
+
+		char foundAsString[64];
+		XMLUtil::ToStr(found, foundAsString, sizeof(foundAsString));
+
+		printf (" %s [%s][%s]\n", testString, expectedAsString, foundAsString );
+	}
 
 	if ( pass )
 		++gPass;


### PR DESCRIPTION
This addresses https://github.com/leethomason/tinyxml2/issues/710 When `XMLText()` is invoked to compare two `int64_t` values those are sliced when printing.