### PR TITLE
Correct assigment interface for StrPair

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -190,7 +190,7 @@ private:
     char*   _end;
 
     StrPair( const StrPair& other );	// not supported
-    void operator=( StrPair& other );	// not supported, use TransferTo()
+    void operator=( const StrPair& other );	// not supported, use TransferTo()
 };
 
 


### PR DESCRIPTION
Assigment operator takes non-const reference when const reference is the norm.