### PR TITLE
tinyxml2.pc.in: restore prefix to lib/include dir

### DIFF
--- a/tinyxml2.pc.in
+++ b/tinyxml2.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: TinyXML2

--- a/tinyxml2.pc.in
+++ b/tinyxml2.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: TinyXML2
 Description: simple, small, C++ XML parser


### PR DESCRIPTION
Since d89d6d9551e5343de4f70ac534f61c3057713f92, the `tinyxml2.pc` file is missing the install prefix from the `includedir` and `libdir` variables. Here is what I see on my system:

~~~
prefix=/usr/local/Cellar/tinyxml2/7.0.0
exec_prefix=${prefix}
libdir=lib
includedir=include

Name: TinyXML2
Description: simple, small, C++ XML parser
Version: 7.0.0
Libs: -L${libdir} -ltinyxml2
Cflags: -I${includedir}
~~~

This restores the prefix to those variables within the pc file.

Also, I noticed this after testing the new homebrew release of 7.0.0, so I would request a 7.0.1 patch release with this change, assuming that it is accepted.