### PR TITLE
CMakeList.txt: fix wrong version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,14 @@ configure_package_config_file(
   "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Config.cmake"
   INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}"
 )
+write_basic_package_version_file(
+  "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}ConfigVersion.cmake"
+  VERSION ${GENERIC_LIB_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
 install(FILES
         ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Config.cmake
+        ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}ConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME})
 
 install(EXPORT ${CMAKE_PROJECT_NAME}Targets NAMESPACE tinyxml2::


### PR DESCRIPTION
Using find_package() with version argument, CMake return wrong version error. This commit resolves this.