### PR TITLE
Issue 742: allow intermittent calls of XMLPrinter::ClearBuffer

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2253,10 +2253,10 @@ public:
     	If in print to memory mode, reset the buffer to the
     	beginning.
     */
-    void ClearBuffer() {
+    void ClearBuffer( bool resetToFirstElement = true ) {
         _buffer.Clear();
         _buffer.Push(0);
-		_firstElement = true;
+		_firstElement = resetToFirstElement;
     }
 
 protected:


### PR DESCRIPTION
XMLPrinter::ClearBuffer shouldn't set _firstElement to true, unless
called after the document is completely generated. Otherwise, the
layout of the XML file is messed up when the buffer is flushed
intermittently. This commit enables this using a default-initialized
parameter, chosen such that the existing behavior remains uneffected.