### PR TITLE
Fixed -Wold-style-cast warnings from g++.

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -101,9 +101,9 @@ distribution.
 #endif
 
 
-static const char LINE_FEED				= (char)0x0a;			// all line endings are normalized to LF
+static const char LINE_FEED				= static_cast<char>(0x0a);			// all line endings are normalized to LF
 static const char LF = LINE_FEED;
-static const char CARRIAGE_RETURN		= (char)0x0d;			// CR gets filtered out
+static const char CARRIAGE_RETURN		= static_cast<char>(0x0d);			// CR gets filtered out
 static const char CR = CARRIAGE_RETURN;
 static const char SINGLE_QUOTE			= '\'';
 static const char DOUBLE_QUOTE			= '\"';
@@ -430,22 +430,22 @@ void XMLUtil::ConvertUTF32ToUTF8( unsigned long input, char* output, int* length
     switch (*length) {
         case 4:
             --output;
-            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
             //fall through
         case 3:
             --output;
-            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
             //fall through
         case 2:
             --output;
-            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
             //fall through
         case 1:
             --output;
-            *output = (char)(input | FIRST_BYTE_MARK[*length]);
+            *output = static_cast<char>(input | FIRST_BYTE_MARK[*length]);
             break;
         default:
             TIXMLASSERT( false );
@@ -585,7 +585,7 @@ void XMLUtil::ToStr( double v, char* buffer, int bufferSize )
 void XMLUtil::ToStr(int64_t v, char* buffer, int bufferSize)
 {
 	// horrible syntax trick to make the compiler happy about %lld
-	TIXML_SNPRINTF(buffer, bufferSize, "%lld", (long long)v);
+	TIXML_SNPRINTF(buffer, bufferSize, "%lld", static_cast<long long>(v));
 }
 
 
@@ -646,7 +646,7 @@ bool XMLUtil::ToInt64(const char* str, int64_t* value)
 {
 	long long v = 0;	// horrible syntax trick to make the compiler happy about %lld
 	if (TIXML_SSCANF(str, "%lld", &v) == 1) {
-		*value = (int64_t)v;
+		*value = static_cast<int64_t>(v);
 		return true;
 	}
 	return false;
@@ -2194,7 +2194,7 @@ template
 struct LongFitsIntoSizeTMinusOne {
     static bool Fits( unsigned long value )
     {
-        return value < (size_t)-1;
+        return value < static_cast<size_t>(-1);
     }
 };
 
@@ -2290,7 +2290,7 @@ XMLError XMLDocument::Parse( const char* p, size_t len )
         SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
         return _errorID;
     }
-    if ( len == (size_t)(-1) ) {
+    if ( len == static_cast<size_t>(-1) ) {
         len = strlen( p );
     }
     TIXMLASSERT( _charBuffer == 0 );
@@ -2424,13 +2424,13 @@ XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
     }
     for( int i=0; i<NUM_ENTITIES; ++i ) {
         const char entityValue = entities[i].value;
-        const unsigned char flagIndex = (unsigned char)entityValue;
+        const unsigned char flagIndex = static_cast<unsigned char>(entityValue);
         TIXMLASSERT( flagIndex < ENTITY_RANGE );
         _entityFlag[flagIndex] = true;
     }
-    _restrictedEntityFlag[(unsigned char)'&'] = true;
-    _restrictedEntityFlag[(unsigned char)'<'] = true;
-    _restrictedEntityFlag[(unsigned char)'>'] = true;	// not required, but consistency is nice
+    _restrictedEntityFlag[static_cast<unsigned char>('&')] = true;
+    _restrictedEntityFlag[static_cast<unsigned char>('<')] = true;
+    _restrictedEntityFlag[static_cast<unsigned char>('>')] = true;	// not required, but consistency is nice
     _buffer.Push( 0 );
 }
 
@@ -2505,10 +2505,10 @@ void XMLPrinter::PrintString( const char* p, bool restricted )
                 // Check for entities. If one is found, flush
                 // the stream up until the entity, write the
                 // entity, and keep looking.
-                if ( flag[(unsigned char)(*q)] ) {
+                if ( flag[static_cast<unsigned char>(*q)] ) {
                     while ( p < q ) {
                         const size_t delta = q - p;
-                        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
+                        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : static_cast<int>(delta);
                         Write( p, toPrint );
                         p += toPrint;
                     }
@@ -2536,7 +2536,7 @@ void XMLPrinter::PrintString( const char* p, bool restricted )
         // string if an entity wasn't found.
         if ( p < q ) {
             const size_t delta = q - p;
-            const int toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
+            const int toPrint = ( INT_MAX < delta ) ? INT_MAX : static_cast<int>(delta);
             Write( p, toPrint );
         }
     }

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1684,7 +1684,7 @@ public:
     	specified, TinyXML-2 will assume 'xml' points to a
     	null terminated string.
     */
-    XMLError Parse( const char* xml, size_t nBytes=(size_t)(-1) );
+    XMLError Parse( const char* xml, size_t nBytes=static_cast<size_t>(-1) );
 
     /**
     	Load an XML file from disk.


### PR DESCRIPTION
This PR fixes -Wold-style-cast warnings from g++:

```
In file included from tinyxml2.cpp:24:
tinyxml2.h:1687:63: warning: use of old-style cast to ‘size_t’ {aka ‘long unsigned int’} [-Wold-style-cast]
     XMLError Parse( const char* xml, size_t nBytes=(size_t)(-1) );
                                                               ^
                                                    ------------
                                                    static_cast<size_t> ((-1))
tinyxml2.cpp:104:40: warning: use of old-style cast to ‘char’ [-Wold-style-cast]
 static const char LINE_FEED    = (char)0x0a;   // all line endings are normalized to LF
                                        ^~~~
                                  ----------
                                  static_cast<char> (0x0a)
tinyxml2.cpp:106:44: warning: use of old-style cast to ‘char’ [-Wold-style-cast]
 static const char CARRIAGE_RETURN  = (char)0x0d;   // CR gets filtered out
                                            ^~~~
                                      ----------
                                      static_cast<char> (0x0d)
tinyxml2.cpp: In static member function ‘static void tinyxml2::XMLUtil::ConvertUTF32ToUTF8(long unsigned int, char*, int*)’:
tinyxml2.cpp:433:61: warning: use of old-style cast to ‘char’ [-Wold-style-cast]
             *output = (char)((input | BYTE_MARK) & BYTE_MASK);
                                                             ^
                       ------
                       static_cast<char> (                    )
tinyxml2.cpp:438:61: warning: use of old-style cast to ‘char’ [-Wold-style-cast]
             *output = (char)((input | BYTE_MARK) & BYTE_MASK);
                                                             ^
                       ------
                       static_cast<char> (                    )
tinyxml2.cpp:443:61: warning: use of old-style cast to ‘char’ [-Wold-style-cast]
             *output = (char)((input | BYTE_MARK) & BYTE_MASK);
                                                             ^
                       ------
                       static_cast<char> (                    )
tinyxml2.cpp:448:62: warning: use of old-style cast to ‘char’ [-Wold-style-cast]
             *output = (char)(input | FIRST_BYTE_MARK[*length]);
                                                              ^
                       ------
                       static_cast<char> (                     )
tinyxml2.cpp: In static member function ‘static void tinyxml2::XMLUtil::ToStr(int64_t, char*, int)’:
tinyxml2.cpp:588:56: warning: use of old-style cast to ‘long long int’ [-Wold-style-cast]
  TIXML_SNPRINTF(buffer, bufferSize, "%lld", (long long)v);
                                                        ^
                                             ------------
                                             static_cast<long long> (v)
tinyxml2.cpp: In static member function ‘static bool tinyxml2::XMLUtil::ToInt64(const char*, int64_t*)’:
tinyxml2.cpp:649:21: warning: use of old-style cast to ‘int64_t’ {aka ‘long int’} [-Wold-style-cast]
   *value = (int64_t)v;
                     ^
            ----------
            static_cast<int64_t> (v)
tinyxml2.cpp: In static member function ‘static bool tinyxml2::LongFitsIntoSizeTMinusOne<<anonymous> >::Fits(long unsigned int)’:
tinyxml2.cpp:2197:33: warning: use of old-style cast to ‘size_t’ {aka ‘long unsigned int’} [-Wold-style-cast]
         return value < (size_t)-1;
                                 ^
tinyxml2.cpp: In member function ‘tinyxml2::XMLError tinyxml2::XMLDocument::Parse(const char*, size_t)’:
tinyxml2.cpp:2293:28: warning: use of old-style cast to ‘size_t’ {aka ‘long unsigned int’} [-Wold-style-cast]
     if ( len == (size_t)(-1) ) {
                            ^
                 ------------
                 static_cast<size_t> ((-1))
tinyxml2.cpp: In constructor ‘tinyxml2::XMLPrinter::XMLPrinter(FILE*, bool, int)’:
tinyxml2.cpp:2427:56: warning: use of old-style cast to ‘unsigned char’ [-Wold-style-cast]
         const unsigned char flagIndex = (unsigned char)entityValue;
                                                        ^~~~~~~~~~~
                                         -
                                         static_cast<  -
                                                       > (         )
tinyxml2.cpp:2431:42: warning: use of old-style cast to ‘unsigned char’ [-Wold-style-cast]
     _restrictedEntityFlag[(unsigned char)'&'] = true;
                                          ^~~
                           -
                           static_cast<  -
                                         > ( )
tinyxml2.cpp:2432:42: warning: use of old-style cast to ‘unsigned char’ [-Wold-style-cast]
     _restrictedEntityFlag[(unsigned char)'<'] = true;
                                          ^~~
                           -
                           static_cast<  -
                                         > ( )
tinyxml2.cpp:2433:42: warning: use of old-style cast to ‘unsigned char’ [-Wold-style-cast]
     _restrictedEntityFlag[(unsigned char)'>'] = true; // not required, but consistency is nice
                                          ^~~
                           -
                           static_cast<  -
                                         > ( )
tinyxml2.cpp: In member function ‘void tinyxml2::XMLPrinter::PrintString(const char*, bool)’:
tinyxml2.cpp:2508:45: warning: use of old-style cast to ‘unsigned char’ [-Wold-style-cast]
                 if ( flag[(unsigned char)(*q)] ) {
                                             ^
                           -
                           static_cast<  -
                                         > (  )
tinyxml2.cpp:2511:82: warning: use of old-style cast to ‘int’ [-Wold-style-cast]
                         const int toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
                                                                                  ^~~~~
                                                                             ----------
                                                                             static_cast<int> (delta)
tinyxml2.cpp:2539:70: warning: use of old-style cast to ‘int’ [-Wold-style-cast]
             const int toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
                                                                      ^~~~~
                                                                 ----------
                                                                 static_cast<int> (delta)
```