### PR TITLE
adjust path of testfile `bomtest.xml` to `resources/out`

### DIFF
--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1702,12 +1702,12 @@ int main( int argc, const char ** argv )
             doc.Print( &printer );
 
             XMLTest( "BOM preservation (compare)", xml_bom_preservation, printer.CStr(), false, true );
-			doc.SaveFile( "resources/bomtest.xml" );
+			doc.SaveFile( "resources/out/bomtest.xml" );
 			XMLTest( "Save bomtest.xml", false, doc.Error() );
         }
 		{
 			XMLDocument doc;
-			doc.LoadFile( "resources/bomtest.xml" );
+			doc.LoadFile( "resources/out/bomtest.xml" );
 			XMLTest( "Load bomtest.xml", false, doc.Error() );
 			XMLTest( "BOM preservation (load)", true, doc.HasBOM(), false );
 


### PR DESCRIPTION
Currently,  the `bomtest.xml`   is saved in `resources` folder,    but the `bomtest.xml`  hasn't be included in the `.gitignore`， and  after I execute 
``` shell
make test
```  
and 
``` shell
make clean
```
the `resources/bomtest.xml`   was marked as `Untracked files ` by  `git`
this PR fixed this issue to place `bomtest.xml` to  `resource/out` folder the same with other test xml files