### PR TITLE
fix issue#712

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2635,8 +2635,6 @@ void XMLPrinter::OpenElement( const char* name, bool compactMode )
 
     if ( _textDepth < 0 && !_firstElement && !compactMode ) {
         Putc( '\n' );
-    }
-    if ( !compactMode ) {
         PrintSpace( _depth );
     }
 


### PR DESCRIPTION
Ability to handle spaces introduced after inserting text between parent and child nodes
```
<?xml version="1.0"?>
<html>
    <head/>
    <body>
        <div>
            <p>Some text in p element           <span>Some text in span element</span>Some other text in p element</p>
        </div>
    </body>
</html>
```