### PR TITLE
Change constants used in 'ToBool' to support MSVC

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -617,17 +617,17 @@ bool XMLUtil::ToBool( const char* str, bool* value )
         *value = (ival==0) ? false : true;
         return true;
     }
-    static const char* TRUE[] = { "true", "True", "TRUE", 0 };
-    static const char* FALSE[] = { "false", "False", "FALSE", 0 };
+    static const char* TRUE_VALS[] = { "true", "True", "TRUE", 0 };
+    static const char* FALSE_VALS[] = { "false", "False", "FALSE", 0 };
 
-    for (int i = 0; TRUE[i]; ++i) {
-        if (StringEqual(str, TRUE[i])) {
+    for (int i = 0; TRUE_VALS[i]; ++i) {
+        if (StringEqual(str, TRUE_VALS[i])) {
             *value = true;
             return true;
         }
     }
-    for (int i = 0; FALSE[i]; ++i) {
-        if (StringEqual(str, FALSE[i])) {
+    for (int i = 0; FALSE_VALS[i]; ++i) {
+        if (StringEqual(str, FALSE_VALS[i])) {
             *value = false;
             return true;
         }


### PR DESCRIPTION
The tokens `TRUE` and `FALSE` are defined in current versions of MSVC, breaking compilation of tinyxml2.cpp in MSVC due to the use of these tokens as variable names in the function `XMLUtil::ToBool`.

Simply changing the variable names to something else resolves the problem.