### PR TITLE
PushNewChild* family of convenience functions

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1961,6 +1961,46 @@ XMLAttribute* XMLElement::CreateAttribute()
     return attrib;
 }
 
+
+XMLElement* XMLElement::PushNewChildElement(const char* name)
+{
+    XMLElement* element = _document->NewElement(name);
+    // by construction, the new element has the same Document, so this
+    // call will always succeed
+    InsertEndChild(element);
+    return element;
+}
+
+XMLComment* XMLElement::PushNewChildComment(const char* comment)
+{
+    XMLComment* element = _document->NewComment(comment);
+    InsertEndChild(element);
+    return element;
+}
+
+XMLText* XMLElement::PushNewChildText(const char* text)
+{
+    XMLText* element = _document->NewText(text);
+    InsertEndChild(element);
+    return element;
+}
+
+XMLDeclaration* XMLElement::PushNewChildDeclaration(const char* text)
+{
+    XMLDeclaration* element = _document->NewDeclaration(text);
+    InsertEndChild(element);
+    return element;
+}
+
+XMLUnknown* XMLElement::PushNewUnknown(const char* text)
+{
+    XMLUnknown* element = _document->NewUnknown(text);
+    InsertEndChild(element);
+    return element;
+}
+
+
+
 //
 //	<ele></ele>
 //	<ele>foo<b>bar</b></ele>

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1640,7 +1640,22 @@ public:
 	/// See QueryIntText()
 	double DoubleText(double defaultValue = 0) const;
 	/// See QueryIntText()
-	float FloatText(float defaultValue = 0) const;
+    float FloatText(float defaultValue = 0) const;
+
+    /**
+        Convenience method to create a new XMLElement and add it as last (right)
+        child of this node. Returns the created and inserted element.
+    */
+    XMLElement* PushNewChildElement(const char* name);
+    /// See PushNewChildElement()
+    XMLComment* PushNewChildComment(const char* comment);
+    /// See PushNewChildElement()
+    XMLText* PushNewChildText(const char* text);
+    /// See PushNewChildElement()
+    XMLDeclaration* PushNewChildDeclaration(const char* text);
+    /// See PushNewChildElement()
+    XMLUnknown* PushNewUnknown(const char* text);
+
 
     // internal:
     enum ElementClosingType {


### PR DESCRIPTION
Adds a set of convenience functions for building up an XMLElement by pushing new elements at the end