### PR TITLE
cmake: Refactor targets export variable and improve comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 # to distinguish between debug and release lib
 set(CMAKE_DEBUG_POSTFIX "d")
 
+set(TARGETS_EXPORT_NAME "${CMAKE_PROJECT_NAME}Targets")
+
 add_library(tinyxml2 tinyxml2.cpp tinyxml2.h)
 
 set_target_properties(tinyxml2 PROPERTIES
@@ -72,8 +74,6 @@ else()
       add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     endif(MSVC)
 endif()
-
-set(TARGETS_EXPORT_NAME "${CMAKE_PROJECT_NAME}Targets")
 
 # Export cmake script that can be used by downstream project
 # via `include()`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,8 @@ endif()
 
 set(TARGETS_EXPORT_NAME "${CMAKE_PROJECT_NAME}Targets")
 
-# export targets for find_package config mode
+# Export cmake script that can be used by downstream project
+# via `include()`
 export(TARGETS tinyxml2
       FILE ${CMAKE_BINARY_DIR}/${TARGETS_EXPORT_NAME}.cmake)
 
@@ -139,6 +140,7 @@ install(FILES
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
         COMPONENT tinyxml2_config)
 
+# Export targets for find_package config mode
 install(EXPORT ${TARGETS_EXPORT_NAME} NAMESPACE tinyxml2::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
         COMPONENT tinyxml2_config)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if(NOT TARGET uninstall)
 endif()
 
 include(CMakePackageConfigHelpers)
-set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(TARGETS_EXPORT_NAME "${CMAKE_PROJECT_NAME}Targets")
 configure_package_config_file(
   "Config.cmake.in"
   "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Config.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,12 +73,14 @@ else()
     endif(MSVC)
 endif()
 
+set(TARGETS_EXPORT_NAME "${CMAKE_PROJECT_NAME}Targets")
+
 # export targets for find_package config mode
 export(TARGETS tinyxml2
-      FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Targets.cmake)
+      FILE ${CMAKE_BINARY_DIR}/${TARGETS_EXPORT_NAME}.cmake)
 
 install(TARGETS tinyxml2
-        EXPORT ${CMAKE_PROJECT_NAME}Targets
+        EXPORT ${TARGETS_EXPORT_NAME}
         RUNTIME 
                 DESTINATION ${CMAKE_INSTALL_BINDIR}
                 COMPONENT tinyxml2_runtime
@@ -121,7 +123,6 @@ if(NOT TARGET uninstall)
 endif()
 
 include(CMakePackageConfigHelpers)
-set(TARGETS_EXPORT_NAME "${CMAKE_PROJECT_NAME}Targets")
 configure_package_config_file(
   "Config.cmake.in"
   "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}Config.cmake"
@@ -138,6 +139,6 @@ install(FILES
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
         COMPONENT tinyxml2_config)
 
-install(EXPORT ${CMAKE_PROJECT_NAME}Targets NAMESPACE tinyxml2::
+install(EXPORT ${TARGETS_EXPORT_NAME} NAMESPACE tinyxml2::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}
         COMPONENT tinyxml2_config)


### PR DESCRIPTION
Hi, this PR does the following:

- Refactor the `TARGETS_EXPORT_NAME` variable. Previously it was completely unused and there were multiple instances of `${CMAKE_PROJECT_NAME}Targets` copied around the file. This moves the variable definition to the top, and then replaces those all the copy-pasted code with the variable.
- Corrects the comments. Previously there was a comment at the `export()` command that mentioned `find_package`. It's actually the `install(EXPORT...` at the bottom that's related to `find_package`. The `export` command purely generates a script in the build dir.