### PR TITLE
cmake: Use a namespace for the tinyxml2 target in local export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,8 @@ endif()
 # Export cmake script that can be used by downstream project
 # via `include()`
 export(TARGETS tinyxml2
-      FILE ${CMAKE_BINARY_DIR}/${TARGETS_EXPORT_NAME}.cmake)
+       NAMESPACE tinyxml2::
+       FILE ${CMAKE_BINARY_DIR}/${TARGETS_EXPORT_NAME}.cmake)
 
 install(TARGETS tinyxml2
         EXPORT ${TARGETS_EXPORT_NAME}


### PR DESCRIPTION
This makes the locally exported (via `export()`) cmake target script consistent with 
the system exported one (via `install(EXPORT...`). (see line 141)

Previously in the locally (cmake build dir) exported cmake script,
there was no namespace, so the targets would directly be available
in the global namespace. Users would do something like:

    include(cmake/tinyxml2Targets.cmake)
    target_link_libraries(main tinyxml2)

Now, a namespace is used. Uses will now look like:

    include(cmake/tinyxml2Targets.cmake)
    target_link_libraries(main tinyxml2::tinyxml2)

This is technically a minor breaking change. It will only affect users
that actually use the *locally* export cmake targets script, which I
expect to be fairly few (note that this is different from the system
exported script). Also, it will only affect users that freshly
build at this commit of tinyxml2, and have the cmake for their
downstream project configured to load it using the locally exported
script. Their cmake will need to be changed from the first snippet
to the second snippet above.