### PR TITLE
Add Makefile outputs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ tinyxml2/temp/
 *.o
 *.vc.db
 *.vc.opendb
+libtinyxml2.a
+xmltest


### PR DESCRIPTION
This should improve the Linux experience for any Linux developers using the supplied `Makefile`.
