### PR TITLE
Remove `clean` before `test` or `check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ clean:
 distclean:
 	-$(RM) *.o xmltest libtinyxml2.a
 
-test: clean xmltest
+test: xmltest
 	./xmltest
 
 # Standard GNU target
-check: clean xmltest
+check: xmltest
 	./xmltest
 
 staticlib: libtinyxml2.a


### PR DESCRIPTION
The `clean` doesn't appear to serve a purpose. Make already does dependency tracking, so if files are out of date they will be rebuilt.

The `clean` rule does however cause problems when the test executable already exists. In that case it will delete outputs, including the test executable, and then fail. By the time the test executable was deleted, it was already determined that it was up to date, and so does not get rebuilt. You end up having to run the command twice, each time seesawing between deleting outputs or generating outputs and running the tests.

----

Example problem output from having `clean` as a prerequisite:
```
make test
rm -f *.o xmltest libtinyxml2.a
./xmltest
make: ./xmltest: Command not found
Makefile:45: recipe for target 'test' failed
make: *** [test] Error 127
```
