### PR TITLE
support IntText(),UnsignedText(),Int64Text() for hex value

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -596,7 +596,7 @@ void XMLUtil::ToStr( uint64_t v, char* buffer, int bufferSize )
 
 bool XMLUtil::ToInt( const char* str, int* value )
 {
-    if ( TIXML_SSCANF( str, "%d", value ) == 1 ) {
+    if ( TIXML_SSCANF( str, IsPrefixHex(str) ? "%x" : "%d", value ) == 1 ) {
         return true;
     }
     return false;
@@ -604,7 +604,7 @@ bool XMLUtil::ToInt( const char* str, int* value )
 
 bool XMLUtil::ToUnsigned( const char* str, unsigned *value )
 {
-    if ( TIXML_SSCANF( str, "%u", value ) == 1 ) {
+    if ( TIXML_SSCANF( str, IsPrefixHex(str) ? "%x" : "%u", value ) == 1 ) {
         return true;
     }
     return false;
@@ -657,7 +657,7 @@ bool XMLUtil::ToDouble( const char* str, double* value )
 bool XMLUtil::ToInt64(const char* str, int64_t* value)
 {
 	long long v = 0;	// horrible syntax trick to make the compiler happy about %lld
-	if (TIXML_SSCANF(str, "%lld", &v) == 1) {
+	if (TIXML_SSCANF(str, IsPrefixHex(str) ? "%llx" : "%lld", &v) == 1) {
 		*value = static_cast<int64_t>(v);
 		return true;
 	}
@@ -667,7 +667,7 @@ bool XMLUtil::ToInt64(const char* str, int64_t* value)
 
 bool XMLUtil::ToUnsigned64(const char* str, uint64_t* value) {
     unsigned long long v = 0;	// horrible syntax trick to make the compiler happy about %llu
-    if(TIXML_SSCANF(str, "%llu", &v) == 1) {
+    if(TIXML_SSCANF(str, IsPrefixHex(str) ? "%llx" : "%llu", &v) == 1) {
         *value = (uint64_t)v;
         return true;
     }

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -590,6 +590,13 @@ public:
                || ch == '-';
     }
 
+    inline static bool IsPrefixHex( const char* p) {
+        while (p && *p != '\0' && !isdigit(*p)) {
+            ++p;
+        }
+        return *p == '0' && ( *(p + 1) == 'x' || *(p + 1) == 'X');
+    }
+
     inline static bool StringEqual( const char* p, const char* q, int nChar=INT_MAX )  {
         if ( p == q ) {
             return true;
@@ -1478,7 +1485,7 @@ public:
         XMLAttribute* a = FindOrCreateAttribute(name);
         a->SetAttribute(value);
     }
-    
+
     /// Sets the named attribute to value.
     void SetAttribute( const char* name, bool value )			{
         XMLAttribute* a = FindOrCreateAttribute( name );

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -1577,6 +1577,24 @@ int main( int argc, const char ** argv )
         XMLTest("FloatText()) test", true, test6);
     }
 
+    {
+        //API:IntText(),UnsignedText(),Int64Text(), hex value test
+        const char* xml = "<point> <IntText>  -0x2020</IntText> <UnsignedText>0x2020</UnsignedText> \
+						   <Int64Text> +0x1234</Int64Text></point>";
+        XMLDocument doc;
+        doc.Parse(xml);
+
+        const XMLElement* pointElement = doc.RootElement();
+        int test1 = pointElement->FirstChildElement("IntText")->IntText();
+        XMLTest("IntText() hex value test", -0x2020, test1);
+
+        unsigned test2 = pointElement->FirstChildElement("UnsignedText")->UnsignedText();
+        XMLTest("UnsignedText() hex value test", static_cast<unsigned>(0x2020), test2);
+
+        int64_t test3 = pointElement->FirstChildElement("Int64Text")->Int64Text();
+        XMLTest("Int64Text() hex value test", static_cast<int64_t>(+0x1234), test3);
+    }
+
 	{
 		//API:ShallowEqual() test
 		const char* xml = "<playlist id = 'playlist'>"


### PR DESCRIPTION
testcase: 
```xml
<point>
    <IntText>  -0x2020</IntText>
    <UnsignedText>0x2020</UnsignedText>
    <Int64Text> +0x1234</Int64Text>
</point>
```

support hex value, `IntText`, `UnsignedText` and `Int64Text` shouldn't be zero.