### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -267,6 +267,19 @@ an Xcode project, a Code::Blocks project, and a cmake CMakeLists.txt included to
 The top of tinyxml.h even has a simple g++ command line if you are using Unix/Linux/BSD and
 don't want to use a build system.
 
+Building TinyXML-2 - Using vcpkg
+--------------------------------
+
+You can download and install TinyXML-2 using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install tinyxml2
+
+The TinyXML-2 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Versioning
 ----------
 


### PR DESCRIPTION
TinyXML-2 is available as a port in vcpkg, a C++ library manager that simplifies installation for tinyxml2 and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build tinyxml2, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.