### PR TITLE
cmake: Removes TINYXML2_EXPORT compile definition when building static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,7 @@ set(GENERIC_LIB_SOVERSION "8")
 ################################
 # Add targets
 # By Default shared library is being built
-# To build static libs also - Do cmake . -DBUILD_STATIC_LIBS:BOOL=ON
-# User can choose not to build shared library by using cmake -DBUILD_SHARED_LIBS:BOOL=OFF
-# To build only static libs use cmake . -DBUILD_SHARED_LIBS:BOOL=OFF -DBUILD_STATIC_LIBS:BOOL=ON
+# To build static libs use cmake . -DBUILD_SHARED_LIBS:BOOL=OFF
 # To build the tests, use cmake . -DBUILD_TESTS:BOOL=ON
 # To disable the building of the tests, use cmake . -DBUILD_TESTS:BOOL=OFF
 
@@ -51,9 +49,12 @@ set(CMAKE_DEBUG_POSTFIX "d")
 add_library(tinyxml2 tinyxml2.cpp tinyxml2.h)
 
 set_target_properties(tinyxml2 PROPERTIES
-        COMPILE_DEFINITIONS "TINYXML2_EXPORT"
 	VERSION "${GENERIC_LIB_VERSION}"
 	SOVERSION "${GENERIC_LIB_SOVERSION}")
+
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(tinyxml2 PRIVATE TINYXML2_EXPORT)
+endif()
 
 target_compile_definitions(tinyxml2 PUBLIC $<$<CONFIG:Debug>:TINYXML2_DEBUG>)
 


### PR DESCRIPTION
This pull request prevents symbols from being exported from a shared library that links with tinxyml2 when tinyxml2 is built as a static library. With this change, symbols will only be exported if tinyxml2 is built as a shared library. This also removes references to the BUILD_STATIC_LIBS CMake variable in the documentation as that variable is not used. 

NOTE: This exclusively impacts Windows/MSVC platforms as the visibility rules with other platforms are different. 