### PR TITLE
Sharpened check for 64-bit Unix when defining fseek/ftell macros.

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -106,7 +106,7 @@ distribution.
 #elif defined(__APPLE__)
 	#define TIXML_FSEEK fseeko
 	#define TIXML_FTELL ftello
-#elif defined(__x86_64__)
+#elif defined(__unix__) && defined(__x86_64__)
 	#define TIXML_FSEEK fseeko64
 	#define TIXML_FTELL ftello64
 #else


### PR DESCRIPTION
This should fix the failing build on VxWorks, as mentioned by @razr in #786.

That said, it doesn't provide the ability to open large files on VxWorks.