### PR TITLE
XMLPrinter: Fix first line indentation

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2659,22 +2659,33 @@ void XMLPrinter::PushHeader( bool writeBOM, bool writeDec )
     }
 }
 
-
-void XMLPrinter::OpenElement( const char* name, bool compactMode )
+void XMLPrinter::PrepareForNewNode( bool compactMode )
 {
     SealElementIfJustOpened();
-    _stack.Push( name );
 
-    if ( _textDepth < 0 && !_firstElement && !compactMode ) {
+    if ( compactMode ) {
+        return;
+    }
+
+    if ( _firstElement ) {
+        PrintSpace (_depth);
+    } else if ( _textDepth < 0) {
         Putc( '\n' );
         PrintSpace( _depth );
     }
+
+    _firstElement = false;
+}
+
+void XMLPrinter::OpenElement( const char* name, bool compactMode )
+{
+    PrepareForNewNode( compactMode );
+    _stack.Push( name );
 
     Write ( "<" );
     Write ( name );
 
     _elementJustOpened = true;
-    _firstElement = false;
     ++_depth;
 }
 
@@ -2850,12 +2861,7 @@ void XMLPrinter::PushText( double value )
 
 void XMLPrinter::PushComment( const char* comment )
 {
-    SealElementIfJustOpened();
-    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
-        Putc( '\n' );
-        PrintSpace( _depth );
-    }
-    _firstElement = false;
+    PrepareForNewNode( _compactMode );
 
     Write( "<!--" );
     Write( comment );
@@ -2865,12 +2871,7 @@ void XMLPrinter::PushComment( const char* comment )
 
 void XMLPrinter::PushDeclaration( const char* value )
 {
-    SealElementIfJustOpened();
-    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
-        Putc( '\n' );
-        PrintSpace( _depth );
-    }
-    _firstElement = false;
+    PrepareForNewNode( _compactMode );
 
     Write( "<?" );
     Write( value );
@@ -2880,12 +2881,7 @@ void XMLPrinter::PushDeclaration( const char* value )
 
 void XMLPrinter::PushUnknown( const char* value )
 {
-    SealElementIfJustOpened();
-    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
-        Putc( '\n' );
-        PrintSpace( _depth );
-    }
-    _firstElement = false;
+    PrepareForNewNode( _compactMode );
 
     Write( "<!" );
     Write( value );

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2332,6 +2332,11 @@ protected:
     DynArray< const char*, 10 > _stack;
 
 private:
+    /**
+       Prepares to write a new node. This includes sealing an element that was
+       just opened, and writing any whitespace necessary if not in compact mode.
+     */
+    void PrepareForNewNode( bool compactMode );
     void PrintString( const char*, bool restrictedEntitySet );	// prints out, after detecting entities.
 
     bool _firstElement;


### PR DESCRIPTION
Fix indentation of first line when called with `!compactMode` and non-zero `depth`. This fixes a regression introduced by https://github.com/leethomason/tinyxml2/pull/773:

From a test build of `cppcheck` after upgrading tinyxml2:
```
/<<PKGBUILDDIR>>/test/testerrorlogger.cpp:196(TestErrorLogger::ToXmlV2): Assertion failed. 
Expected:                                                                                                           
        <error id=\"errorId\" severity=\"error\" msg=\"Programming error.\" verbose=\"Verbose error\">\n
            <location file=\"foo.cpp\" line=\"5\" column=\"1\"/>\n                                                  
        </error>                                                                                                    
                                                          
Actual:                                                                                                             
<error id=\"errorId\" severity=\"error\" msg=\"Programming error.\" verbose=\"Verbose error\">\n                    
            <location file=\"foo.cpp\" line=\"5\" column=\"1\"/>\n                                                  
        </error>                                                                                                    

```