### PR TITLE
Suppress UndefinedBehaviorSanitizer warnings

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -234,13 +234,13 @@ char* StrPair::ParseName( char* p )
     if ( !p || !(*p) ) {
         return 0;
     }
-    if ( !XMLUtil::IsNameStartChar( *p ) ) {
+    if ( !XMLUtil::IsNameStartChar( (unsigned char) *p ) ) {
         return 0;
     }
 
     char* const start = p;
     ++p;
-    while ( *p && XMLUtil::IsNameChar( *p ) ) {
+    while ( *p && XMLUtil::IsNameChar( (unsigned char) *p ) ) {
         ++p;
     }
 
@@ -1909,7 +1909,7 @@ char* XMLElement::ParseAttributes( char* p, int* curLineNumPtr )
         }
 
         // attribute.
-        if (XMLUtil::IsNameStartChar( *p ) ) {
+        if (XMLUtil::IsNameStartChar( (unsigned char) *p ) ) {
             XMLAttribute* attrib = CreateAttribute();
             TIXMLASSERT( attrib );
             attrib->_parseLineNum = _document->_parseCurLineNum;


### PR DESCRIPTION
I compiled tinyxml2 with the following changes to CMakeLists.txt:
-------------------------------------------------- ------------------------------------------
set (CMAKE_C_COMPILER "/ usr / local / bin / clang10")
set (CMAKE_CXX_COMPILER "/ usr / local / bin / clang ++ 10")
add_compile_options (-g)
add_compile_options (-fsanitize = address, undefined, integer, alignment, bool, builtin, bounds, enum, function, nonnull-attribute, null, object-size, pointer-overflow, return, returns-nonnull-attribute, unreachable, vla-bound , vptr)

set_source_files_properties (tinyxml2.cpp tinyxml2.h
                            PROPERTIES COMPILE_FLAGS -fsanitize = address, undefined, integer, alignment, bool, builtin, bounds, enum, function, nonnull-attribute, null, object-size, pointer-overflow, return, returns-nonnull-attribute, unreachable, vla-bound , vptr)
TARGET_LINK_LIBRARIES (tinyxml2 /usr/local/llvm10/lib/clang/10.0.0/lib/freebsd/libclang_rt.asan-x86_64.a /usr/local/llvm10/lib/clang/10.0.0/lib/freebsd/libang asan_cxx-x86_64.a /usr/local/llvm10/lib/clang/10.0.0/lib/freebsd/libclang_rt.ubsan_standalone-x86_64.a /usr/local/llvm10/lib/clang/10.0.0/lib/freebsd/ libclang_rt.ubsan_standalone_cxx-x86_64.a -lpthread)
-------------------------------------------------- ------------------------------------------
(Sorry for the dirty code.)

And launched the xmltest utility:
-------------------------------------------------- ------------------------------------------
/home/qqq/17_tinyxml2/tinyxml2-master/tinyxml2.cpp:237:37: runtime error: implicit conversion from type 'char' of value -48 (8-bit, signed) to type 'unsigned char' changed the value to 208 (8-bit, unsigned)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/qqq/17_tinyxml2/tinyxml2-master/tinyxml2.cpp:237:37 in
/home/qqq/17_tinyxml2/tinyxml2-master/tinyxml2.cpp:243:40: runtime error: implicit conversion from type 'char' of value -96 (8-bit, signed) to type 'unsigned char' changed the value to 160 (8-bit, unsigned)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/qqq/17_tinyxml2/tinyxml2-master/tinyxml2.cpp:243:40 in
/home/qqq/17_tinyxml2/tinyxml2-master/tinyxml2.cpp:1912:39: runtime error: implicit conversion from type 'char' of value -48 (8-bit, signed) to type 'unsigned char' changed the value to 208 (8-bit, unsigned)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/qqq/17_tinyxml2/tinyxml2-master/tinyxml2.cpp:1912:39 in
-------------------------------------------------- ------------------------------------------