### PR TITLE
cmake: Don't export symbols if building static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,7 @@ set(GENERIC_LIB_SOVERSION "8")
 ################################
 # Add targets
 # By Default shared library is being built
-# To build static libs also - Do cmake . -DBUILD_STATIC_LIBS:BOOL=ON
-# User can choose not to build shared library by using cmake -DBUILD_SHARED_LIBS:BOOL=OFF
-# To build only static libs use cmake . -DBUILD_SHARED_LIBS:BOOL=OFF -DBUILD_STATIC_LIBS:BOOL=ON
+# User can choose to build static library by using cmake -DBUILD_SHARED_LIBS:BOOL=OFF
 # To build the tests, use cmake . -DBUILD_TESTS:BOOL=ON
 # To disable the building of the tests, use cmake . -DBUILD_TESTS:BOOL=OFF
 
@@ -51,7 +49,7 @@ set(CMAKE_DEBUG_POSTFIX "d")
 add_library(tinyxml2 tinyxml2.cpp tinyxml2.h)
 
 set_target_properties(tinyxml2 PROPERTIES
-        COMPILE_DEFINITIONS "TINYXML2_EXPORT"
+	DEFINE_SYMBOL "TINYXML2_EXPORT"
 	VERSION "${GENERIC_LIB_VERSION}"
 	SOVERSION "${GENERIC_LIB_SOVERSION}")
 


### PR DESCRIPTION
If you build tinyxml2 as a static library on Windows, its symbols are exported from any DLL or EXE you create. This generally shouldn't happen.