### PR TITLE
cmake: Fix debug postfix in pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,9 @@ endif()
 
 install(FILES tinyxml2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT tinyxml2_headers)
 
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+  set(LIB_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+endif()
 configure_file(tinyxml2.pc.in tinyxml2.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT tinyxml2_config)
 

--- a/tinyxml2.pc.in
+++ b/tinyxml2.pc.in
@@ -6,5 +6,5 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 Name: TinyXML2
 Description: simple, small, C++ XML parser
 Version: @GENERIC_LIB_VERSION@
-Libs: -L${libdir} -ltinyxml2
+Libs: -L${libdir} -ltinyxml2@LIB_POSTFIX@
 Cflags: -I${includedir}


### PR DESCRIPTION
CMakeLists.txt uses `set(CMAKE_DEBUG_POSTFIX "d")` to distinguish
between debug and release lib. Use this postfix also in the
generated **`tinyxml2.pc`** file in case of a CMake Debug build.
This results in the following contents of **`tinyxml2.pc`**
- Release:
  `Libs: -L${libdir} -ltinyxml2`
- Debug:
  `Libs: -L${libdir} -ltinyxml2d`
