### PR TITLE
removed overhead of clear error

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2427,6 +2427,13 @@ void XMLDocument::Print( XMLPrinter* streamer ) const
 }
 
 
+void XMLDocument::ClearError() {
+    _errorID = XML_SUCCESS;
+    _errorLineNum = 0;
+    _errorStr.Reset();
+}
+
+
 void XMLDocument::SetError( XMLError error, int lineNum, const char* format, ... )
 {
     TIXMLASSERT( error >= 0 && error < XML_ERROR_COUNT );

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1873,9 +1873,8 @@ public:
     */
     void DeleteNode( XMLNode* node );
 
-    void ClearError() {
-        SetError(XML_SUCCESS, 0, 0);
-    }
+    /// Clears the error flags.
+    void ClearError();
 
     /// Return true if there was an error parsing the document.
     bool Error() const {


### PR DESCRIPTION
fixing #826
This introduces an observable change in behaviour, in that previously, if there was no error, the error string variable would point to an actual string, whereas now it is nullptr.

One thing I noticed while running the test cases, the one on line 2000 seems to have a rather misleading message, because as far as I can see `ClearError` is never involved here.
```
XMLDocument doc;
for( int i = 0; i < XML_ERROR_COUNT; i++ ) {
	const XMLError error = static_cast<XMLError>(i);
	const char* name = XMLDocument::ErrorIDToName(error);
	XMLTest( "ErrorName() not null after ClearError()", true, name != 0 );
	if( name == 0 ) {
		// passing null pointer into strlen() is undefined behavior, so
		// compiler is allowed to optimise away the null test above if it's
		// as reachable as the strlen() call
		continue;
	}
	XMLTest( "ErrorName() not empty after ClearError()", true, strlen(name) > 0 );
}
```