### PR TITLE
Fix for enum in StrPair and TIXMLASSERT define behaviour

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -136,7 +136,7 @@ class XMLPrinter;
 class TINYXML2_LIB StrPair
 {
 public:
-    enum Mode : uint32_t {
+    enum Mode {
         NEEDS_ENTITY_PROCESSING			= 0x01,
         NEEDS_NEWLINE_NORMALIZATION		= 0x02,
         NEEDS_WHITESPACE_COLLAPSING     = 0x04,

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -79,6 +79,7 @@ distribution.
 #endif
 
 
+#if !defined(TIXMLASSERT)
 #if defined(TINYXML2_DEBUG)
 #   if defined(_MSC_VER)
 #       // "(void)0," is for suppressing C4127 warning in "assert(false)", "assert(true)" and the like
@@ -93,7 +94,7 @@ distribution.
 #else
 #   define TIXMLASSERT( x )               {}
 #endif
-
+#endif
 
 /* Versioning, past 1.0.14:
 	http://semver.org/
@@ -135,7 +136,7 @@ class XMLPrinter;
 class TINYXML2_LIB StrPair
 {
 public:
-    enum {
+    enum Mode : uint32_t {
         NEEDS_ENTITY_PROCESSING			= 0x01,
         NEEDS_NEWLINE_NORMALIZATION		= 0x02,
         NEEDS_WHITESPACE_COLLAPSING     = 0x04,


### PR DESCRIPTION
Changes to allow using the tinyxml2 .h/cpp into a SCU:
- Allowing TIXMLASSERT to be defined before including the main header. This is important to allow custom assert macros.
- Fix for enum bitmask usage

Example usage after this:
`#define TINYXML2_DEBUG (DL_DEBUG || DL_RELEASE)`
`#define TIXMLASSERT(x) DL_ASSERT(x)`
`#include <tinyxml2/tinyxml2.h>`