### PR TITLE
Add meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,104 @@
+# Copyright © 2020 Dylan Baker
+
+# This software is provided 'as-is', without any express or implied
+# warranty. In no event will the authors be held liable for any
+# damages arising from the use of this software.
+
+# Permission is granted to anyone to use this software for any
+# purpose, including commercial applications, and to alter it and
+# redistribute it freely, subject to the following restrictions:
+
+# 1. The origin of this software must not be misrepresented; you must
+# not claim that you wrote the original software. If you use this
+# software in a product, an acknowledgment in the product documentation
+# would be appreciated but is not required.
+
+# 2. Altered source versions must be plainly marked as such, and
+# must not be misrepresented as being the original software.
+
+# 3. This notice may not be removed or altered from any source
+# distribution.
+
+project(
+    'tinyxml2',
+    ['cpp'],
+    version : '8.0.0',
+    meson_version : '>= 0.49.0',
+)
+
+cpp = meson.get_compiler('cpp')
+
+tinyxml_extra_args = []
+if cpp.get_argument_syntax() == 'msvc'
+    tinyxml_extra_args += '-D_CRT_SECURE_NO_WARNINGS'
+endif
+
+if get_option('default_library') == 'shared'
+    tinyxml_extra_args += '-DTINYXML2_EXPORT'
+endif
+
+if get_option('debug')
+    tinyxml_extra_args += '-DTINYXML2_DEBUG'
+endif
+
+lib_tinyxml2 = library(
+    'tinyxml2',
+    ['tinyxml2.cpp'],
+    cpp_args : tinyxml_extra_args,
+    gnu_symbol_visibility : 'hidden',
+    version : meson.project_version(),
+    install : true,
+)
+
+dep_tinxyml2 = declare_dependency(
+    link_with : lib_tinyxml2,
+    include_directories : include_directories('.'),
+)
+
+# This is the new way to set dependencies, but let's not break users of older
+# versions of meson
+if meson.version().version_compare('>= 0.54.0')
+  meson.override_dependency('tinyxml2', dep_tinxyml2)
+endif
+
+if get_option('tests')
+    # Try to find a copy command. If this is windows we probably don't have cp,
+    # but if this is msys then we do, so make cp not required in that case, and
+    # try Xcopy if cp isn't found
+    prog_cp = find_program('cp', required : build_machine.system() != 'windows')
+    command = ['-r']
+    if not prog_cp.found()
+        prog_cp = find_program('Xcopy')
+        command = ['/E', '/I']
+    endif
+
+    # Copy the test resources into the build dir
+    run_command(
+        prog_cp,
+        [
+            command,
+            meson.current_source_dir() / 'resources',
+            meson.current_build_dir(),
+        ],
+    )
+
+    test(
+        'xmltest',
+        executable(
+            'xmltest',
+            ['xmltest.cpp'],
+            link_with : [lib_tinyxml2],
+        ),
+        workdir : meson.current_build_dir(),
+    )
+endif
+
+install_headers('tinyxml2.h')
+
+# This is better than using the .in because meson tracks dependencies
+# internally, and will generate a more accurate pkg-config file
+pkg = import('pkgconfig')
+pkg.generate(
+    lib_tinyxml2,
+    description : 'simple, small, C++ XML parser',
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,28 @@
+# Copyright © 2020 Dylan Baker
+
+# This software is provided 'as-is', without any express or implied
+# warranty. In no event will the authors be held liable for any
+# damages arising from the use of this software.
+
+# Permission is granted to anyone to use this software for any
+# purpose, including commercial applications, and to alter it and
+# redistribute it freely, subject to the following restrictions:
+
+# 1. The origin of this software must not be misrepresented; you must
+# not claim that you wrote the original software. If you use this
+# software in a product, an acknowledgment in the product documentation
+# would be appreciated but is not required.
+
+# 2. Altered source versions must be plainly marked as such, and
+# must not be misrepresented as being the original software.
+
+# 3. This notice may not be removed or altered from any source
+# distribution.
+
+option(
+    'tests',
+    type : 'boolean',
+    description : 'Enable unit tests',
+    value : true,
+    yield : true,
+)

--- a/readme.md
+++ b/readme.md
@@ -265,9 +265,31 @@ And additionally a test file:
 * xmltest.cpp
 
 Simply compile and run. There is a visual studio 2019 project included, a simple Makefile,
-an Xcode project, a Code::Blocks project, and a cmake CMakeLists.txt included to help you.
-The top of tinyxml.h even has a simple g++ command line if you are using Unix/Linux/BSD and
-don't want to use a build system.
+an Xcode project, a Code::Blocks project, a cmake CMakeLists.txt, and a meson.build are
+included to help you. The top of tinyxml.h even has a simple g++ command line if you are
+using Unix/Linux/BSD and don't want to use a build system.
+
+Using as a Meson Subproject
+---------------------------
+
+Create a wrap file such as:
+```ini
+[wrap-git]
+url = https://github.com/leethomason/tinyxml2.git
+revision = 8.0.1  # this can be any commit-ish (tag, sha) or the special value `head`
+```
+
+or, if you prefer to not use git
+
+```ini
+[wrap-file]
+directory = tinyxml2-8.0.1  # this is the name of the directory after de-compressing
+source_url = https://github.com/leethomason/tinyxml2/archive/8.0.1.tar.gz
+source_hash = sha256sum of compressed sources
+```
+
+in your project's `subprojects/` folder, and follow the meson documentation
+for using fallbacks.
 
 Building TinyXML-2 - Using vcpkg
 --------------------------------

--- a/setversion.py
+++ b/setversion.py
@@ -134,6 +134,15 @@ def cmakeRule2( line ):
 
 fileProcess( "CMakeLists.txt", cmakeRule2 )
 
+def mesonRule(line):
+	match = re.search(r"(\s*version) : '(\d+.\d+.\d+)',", line)
+	if match:
+		print("1)meson.build version found.")
+		return "{} : '{}.{}.{}',\n".format(match.group(1), major, minor, build)
+	return line
+
+fileProcess("meson.build", mesonRule)
+
 print( "Release note:" )
 print( '1. Build.   g++ -Wall -DTINYXML2_DEBUG tinyxml2.cpp xmltest.cpp -o gccxmltest.exe' )
 print( '2. Commit.  git commit -am"setting the version to ' + versionStr + '"' )


### PR DESCRIPTION
Meson is a build system somewhat like cmake, but meant to be easier to use.
It supports many OSes, including all of the major ones, and
a large number of compilers.

My interest isn't really in convincing people to use meson as the
default here, but meson provides a subproject mechanism that can fetch
external projects and build them with the main project in a single configure/compile process. This
is extremely useful for platforms that lack a (competent) package
manager.

As far as I know the meson build does everything the cmake build does,
with one exception: generate the cmake config/version files. meson can
generate these files, but only in simple cases, not using export targets
like tinyxml2 does.