### PR TITLE
Update cmake minimum version to 3.10.2 for Ubuntu 18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-2019, macos-10.15, ubuntu-20.04 ]
+        os: [ windows-2019, macos-10.15, ubuntu-18.04, ubuntu-20.04 ]
         cmake: [ 3.15, 3.x ]
         include:
           - os: windows-2019
             static_postfix: _static
             tree: tree /F
             CXX: cl
+
+          - os: ubuntu-18.04
+            tree: tree
 
           - os: ubuntu-20.04
             tree: tree

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10.2)
 project(tinyxml2 VERSION 8.1.0)
 
 include(CTest)
@@ -71,14 +71,26 @@ set(tinyxml2_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/tinyxml2"
 
 ## CMake targets and export scripts
 
-install(
-    TARGETS tinyxml2 EXPORT tinyxml2-targets
-    RUNTIME COMPONENT tinyxml2_runtime
-    LIBRARY COMPONENT tinyxml2_runtime
-    NAMELINK_COMPONENT tinyxml2_development
-    ARCHIVE COMPONENT tinyxml2_development
-    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-)
+# Set NAMELINK_COMPONENT only if cmake_version >= 3.12
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+    install(
+        TARGETS tinyxml2 EXPORT tinyxml2-targets
+        RUNTIME COMPONENT tinyxml2_runtime
+        LIBRARY COMPONENT tinyxml2_runtime
+        ARCHIVE COMPONENT tinyxml2_development
+                DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    )
+else()
+    install(
+        TARGETS tinyxml2 EXPORT tinyxml2-targets
+        RUNTIME COMPONENT tinyxml2_runtime
+        LIBRARY COMPONENT tinyxml2_runtime
+        NAMELINK_COMPONENT tinyxml2_development
+        ARCHIVE COMPONENT tinyxml2_development
+        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    )
+endif()
 
 # Type-specific targets
 
@@ -112,18 +124,28 @@ install(
 
 ## Headers
 
-install(
-    FILES tinyxml2.h
-    TYPE INCLUDE
-    COMPONENT tinyxml2_development
-)
+if(${CMAKE_VERSION} VERSION_LESS_EQUAL "3.13.5")
+    install(
+        FILES tinyxml2.h
+        COMPONENT tinyxml2_development
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+else()
+    install(
+        FILES tinyxml2.h
+        TYPE INCLUDE
+        COMPONENT tinyxml2_development
+    )
+endif()
 
 ## pkg-config
 
-configure_file(cmake/tinyxml2.pc.in tinyxml2.pc.gen @ONLY)
-file(GENERATE OUTPUT tinyxml2.pc INPUT "${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc.gen")
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc"
-    DESTINATION "${tinyxml2_INSTALL_PKGCONFIGDIR}"
-    COMPONENT tinyxml2_development
-)
+if(${CMAKE_VERSION} VERSION_GREATER "3.14.7")
+    configure_file(cmake/tinyxml2.pc.in tinyxml2.pc.gen @ONLY)
+    file(GENERATE OUTPUT tinyxml2.pc INPUT "${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc.gen")
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/tinyxml2.pc"
+        DESTINATION "${tinyxml2_INSTALL_PKGCONFIGDIR}"
+        COMPONENT tinyxml2_development
+    )
+endif()

--- a/cmake/tinyxml2-config.cmake
+++ b/cmake/tinyxml2-config.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10.2)
 
 set(tinyxml2_known_comps static shared)
 set(tinyxml2_comp_static NO)


### PR DESCRIPTION
In MAVSDK, we support cmake 3.10.2 because that's the version coming with Ubuntu 18.04. I do realize that tinyxml2 was updated to more modern cmake features, and therefore I tried here to keep them, but using a fallback for those newer features.

As a consequence, that removes pkg-config for older versions, but anyway those are not currently supported...

I am not completely sure of the consequences of these changes, but my feeling is that they should have no impact for cmake 3.15+, and it makes sense to me to still support Ubuntu 18.04. If you don't want to, I'll just keep that as a patch step in MAVSDK :+1: :blush:.

This is being tested in MAVSDK's CI [here](https://github.com/mavlink/MAVSDK/pull/1436), together with https://github.com/leethomason/tinyxml2/pull/865