### PR TITLE
Use fseeko and ftello on BSDs

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -103,7 +103,8 @@ distribution.
 #if defined(_WIN64)
 	#define TIXML_FSEEK _fseeki64
 	#define TIXML_FTELL _ftelli64
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__ANDROID__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) \
+	|| defined(__NetBSD__) || defined(__DragonFly__) || defined(__ANDROID__)
 	#define TIXML_FSEEK fseeko
 	#define TIXML_FTELL ftello
 #elif defined(__unix__) && defined(__x86_64__)


### PR DESCRIPTION
fseek64 seems to be specific to glibc and doesn't work an other unix platforms.
(musl and ulibc support it for glibc compatibility)