### PR TITLE
added std::string support

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -32,6 +32,8 @@ distribution.
 #   include <cstdarg>
 #endif
 
+#include <sstream>
+
 #if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
 	// Microsoft Visual Studio, version 2005 and higher. Not WinCE.
 	/*int _snprintf_s(
@@ -562,6 +564,9 @@ const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
     return p+1;
 }
 
+void XMLUtil::ToStr( std::string v, char* buffer, int bufferSize ) {
+    TIXML_SNPRINTF( buffer, bufferSize, "%s", v.c_str() );
+}
 
 void XMLUtil::ToStr( int v, char* buffer, int bufferSize )
 {
@@ -606,6 +611,11 @@ void XMLUtil::ToStr( uint64_t v, char* buffer, int bufferSize )
 {
     // horrible syntax trick to make the compiler happy about %llu
     TIXML_SNPRINTF(buffer, bufferSize, "%llu", (long long)v);
+}
+
+bool XMLUtil::ToStr( const char* str, std::string* value ) {
+    *value = std::string(str);
+    return true;
 }
 
 bool XMLUtil::ToInt(const char* str, int* value)
@@ -1440,6 +1450,12 @@ void XMLAttribute::SetName( const char* n )
     _name.SetStr( n );
 }
 
+XMLError XMLAttribute::QueryStringValue( std::string* value ) const {
+    if ( XMLUtil::ToStr( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
 
 XMLError XMLAttribute::QueryIntValue( int* value ) const
 {
@@ -1604,6 +1620,11 @@ const char* XMLElement::Attribute( const char* name, const char* value ) const
     return 0;
 }
 
+const char* XMLElement::Attribute( const char* name, const std::string& value ) const
+{
+  return Attribute(name, value.c_str());
+}
+
 int XMLElement::IntAttribute(const char* name, int defaultValue) const
 {
 	int i = defaultValue;
@@ -1653,6 +1674,13 @@ float XMLElement::FloatAttribute(const char* name, float defaultValue) const
 	return f;
 }
 
+std::string XMLElement::StringAttribute(const char* name, const std::string& defaultValue) const
+{
+        std::string f = defaultValue;
+        QueryStringAttribute(name, &f);
+        return f;
+}
+
 const char* XMLElement::GetText() const
 {
     /* skip comment node */
@@ -1671,6 +1699,11 @@ const char* XMLElement::GetText() const
     return 0;
 }
 
+void XMLElement::SetText( std::string v ) {
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText(buf);
+}
 
 void	XMLElement::SetText( const char* inText )
 {
@@ -1736,6 +1769,16 @@ void XMLElement::SetText( double v )
     SetText( buf );
 }
 
+XMLError XMLElement::QueryStrText( std::string* fval ) const {
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if (XMLUtil::ToStr( t, fval )) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
 
 XMLError XMLElement::QueryIntText( int* ival ) const
 {

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -41,6 +41,7 @@ distribution.
 #   include <cstring>
 #endif
 #include <stdint.h>
+#include <string>
 
 /*
    TODO: intern strings instead of allocation.
@@ -617,6 +618,7 @@ public:
     static void ConvertUTF32ToUTF8( unsigned long input, char* output, int* length );
 
     // converts primitive types to strings
+    static void ToStr( std::string v, char* buffer, int bufferSize );
     static void ToStr( int v, char* buffer, int bufferSize );
     static void ToStr( unsigned v, char* buffer, int bufferSize );
     static void ToStr( bool v, char* buffer, int bufferSize );
@@ -626,6 +628,7 @@ public:
     static void ToStr(uint64_t v, char* buffer, int bufferSize);
 
     // converts strings to primitive types
+    static bool ToStr( const char* str, std::string* value );
     static bool	ToInt( const char* str, int* value );
     static bool ToUnsigned( const char* str, unsigned* value );
     static bool	ToBool( const char* str, bool* value );
@@ -1219,7 +1222,11 @@ public:
     XMLError QueryDoubleValue( double* value ) const;
     /// See QueryIntValue
     XMLError QueryFloatValue( float* value ) const;
+    /// See QueryIntValue
+    XMLError QueryStringValue( std::string* value ) const;
 
+    /// Set the attribute to a string value.
+    void SetAttribute( const std::string &value );
     /// Set the attribute to a string value.
     void SetAttribute( const char* value );
     /// Set the attribute to value.
@@ -1306,6 +1313,7 @@ public:
     	@endverbatim
     */
     const char* Attribute( const char* name, const char* value=0 ) const;
+    const char* Attribute( const char* name, const std::string& value ) const;
 
     /** Given an attribute name, IntAttribute() returns the value
     	of the attribute interpreted as an integer. The default
@@ -1326,6 +1334,8 @@ public:
 	double DoubleAttribute(const char* name, double defaultValue = 0) const;
     /// See IntAttribute()
 	float FloatAttribute(const char* name, float defaultValue = 0) const;
+    /// See IntAttribute()
+        std::string StringAttribute(const char* name, const std::string& defaultValue = "") const;
 
     /** Given an attribute name, QueryIntAttribute() returns
     	XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
@@ -1399,6 +1409,14 @@ public:
         }
         return a->QueryFloatValue( value );
     }
+    /// See QueryIntAttribute()
+    XMLError QueryStringAttribute( const char* name, std::string* value ) const			{
+      const XMLAttribute* a = FindAttribute( name );
+      if ( !a ) {
+        return XML_NO_ATTRIBUTE;
+      }
+      return a->QueryStringValue( value );
+    }
 
 	/// See QueryIntAttribute()
 	XMLError QueryStringAttribute(const char* name, const char** value) const {
@@ -1461,6 +1479,10 @@ public:
 		return QueryStringAttribute(name, value);
 	}
 
+        XMLError QueryAttribute(const char* name, std::string* value) const {
+          return QueryStringAttribute(name, value);
+        }
+
 	/// Sets the named attribute to value.
     void SetAttribute( const char* name, const char* value )	{
         XMLAttribute* a = FindOrCreateAttribute( name );
@@ -1503,6 +1525,12 @@ public:
     void SetAttribute( const char* name, float value )		{
         XMLAttribute* a = FindOrCreateAttribute( name );
         a->SetAttribute( value );
+    }
+
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, const std::string& value ) {
+      XMLAttribute* a = FindOrCreateAttribute( name );
+      a->SetAttribute( value.c_str() );
     }
 
     /**
@@ -1581,6 +1609,9 @@ public:
     		<foo>Hullaballoo!</foo>
     	@endverbatim
     */
+
+    void SetText( std::string inText );
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
 	void SetText( const char* inText );
     /// Convenience method for setting text inside an element. See SetText() for important limitations.
     void SetText( int value );
@@ -1636,6 +1667,8 @@ public:
     XMLError QueryDoubleText( double* dval ) const;
     /// See QueryIntText()
     XMLError QueryFloatText( float* fval ) const;
+    /// See QueryIntText()
+    XMLError QueryStrText( std::string* fval ) const;
 
 	int IntText(int defaultValue = 0) const;
 

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <string>
 
 #if defined( _MSC_VER ) || defined (WIN32)
 	#include <crtdbg.h>
@@ -627,10 +628,13 @@ int main( int argc, const char ** argv )
 
 		int iVal, iVal2;
 		double dVal, dVal2;
+		const std::string test_string("ThiS is A Sample StrIng with SpeCiaL characters: .-_:{,'**äöüÄÖÜ?ß\\)(/&%$§\"!}][");
+		std::string test_string_query;
 
 		ele->SetAttribute( "str", "strValue" );
 		ele->SetAttribute( "int", 1 );
 		ele->SetAttribute( "double", -1.0 );
+		ele->SetAttribute( "stdString", test_string); 
 
 		const char* answer = 0;
 		ele->QueryAttribute("str", &answer);
@@ -654,8 +658,14 @@ int main( int argc, const char ** argv )
 			XMLError queryResult = ele->QueryAttribute( "double", &dVal2 );
 			XMLTest( "Query double attribute generic", (int)XML_SUCCESS, queryResult);
 		}
-
+		{
+			XMLError queryResult = ele->QueryAttribute( "stdString", &test_string_query );
+			XMLTest( "Query std::string attribute generic", (int)XML_SUCCESS, queryResult);
+		}
+		
+                XMLTest( "Attribute match test", test_string.c_str(), ele->Attribute( "stdString", test_string ) );
 		XMLTest( "Attribute match test", "strValue", ele->Attribute( "str", "strValue" ) );
+		XMLTest( "Attribute round trip. std::string.", test_string.c_str(), test_string.c_str() );
 		XMLTest( "Attribute round trip. c-string.", "strValue", cStr );
 		XMLTest( "Attribute round trip. int.", 1, iVal );
 		XMLTest( "Attribute round trip. double.", -1, (int)dVal );
@@ -663,6 +673,7 @@ int main( int argc, const char ** argv )
 		XMLTest( "Alternate query", true, dVal == dVal2 );
 		XMLTest( "Alternate query", true, iVal == ele->IntAttribute("int") );
 		XMLTest( "Alternate query", true, dVal == ele->DoubleAttribute("double") );
+		XMLTest( "Alternate query", true, test_string == ele->StringAttribute("stdString") );
 	}
 
 	{


### PR DESCRIPTION
I needed for one of my projects support for std::string. I thought that others my want it too.
I tried to respect the existing formatting but I might have failed here.

caveat: 
Since I am lazy I used existing methods for char arrays/pointers. These are restricted too 200 Bytes
see BUF_SIZE in tinyxml2.h 
So every std::string with more characters will be  cropped.
