### PR TITLE
Fix broken documentation links.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+include:
+  - "_*.html"


### PR DESCRIPTION
Force Jekyll to use files whose name begin with an underscore.

@Dfluke suggestion in issue #849 solves the 404 when trying to access _examples_ pages.
Tested to work on my fork: https://mphschmitt.github.io/tinyxml2/_example_2.html