### PR TITLE
Use fseeko()/ftello() on Cygwin

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -104,7 +104,7 @@ distribution.
 	#define TIXML_FSEEK _fseeki64
 	#define TIXML_FTELL _ftelli64
 #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) \
-	|| defined(__NetBSD__) || defined(__DragonFly__) || defined(__ANDROID__)
+	|| defined(__NetBSD__) || defined(__DragonFly__) || defined(__ANDROID__) || (__CYGWIN__)
 	#define TIXML_FSEEK fseeko
 	#define TIXML_FTELL ftello
 #elif defined(__unix__) && defined(__x86_64__)


### PR DESCRIPTION
Cygwin doesn't have fseeko64() & ftello64()