### PR TITLE
CMakeLists.txt: copy resources directory to test directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,13 @@ if (tinyxml2_BUILD_TESTING)
         COMMAND xmltest
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
+     # Copy test resources and create test output directory
+    add_custom_command(TARGET xmltest POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/resources $<TARGET_FILE_DIR:xmltest>/resources
+        COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:xmltest>/resources/out
+        COMMENT "Configuring xmltest resources directory: ${CMAKE_CURRENT_BINARY_DIR}/resources"
+    )
+
 
     set_tests_properties(xmltest PROPERTIES PASS_REGULAR_EXPRESSION ", Fail 0")
 endif ()


### PR DESCRIPTION
the xml files inside the resources are to be used for the
run of xmltest
they were not getting copied from the source directory to the directory
where xmltest was installed

fixes the below error when code built with cmake
./xmltest
Error opening test file 'dream.xml'.
Is your working directory the same as where
the xmltest.cpp and dream.xml file are?

Signed-off-by: Nisha Parrakat <nisha.m.parrakat@bmw.de>
Signed-off-by: Nisha Parrakat <nishaparrakat@gmail.com>