### PR TITLE
Increase depth recursion limit

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -112,7 +112,7 @@ static const int TIXML2_PATCH_VERSION = 0;
 // system, and the capacity of the stack. On the other hand, it's a trivial
 // attack that can result from ill, malicious, or even correctly formed XML,
 // so there needs to be a limit in place.
-static const int TINYXML2_MAX_ELEMENT_DEPTH = 100;
+static const int TINYXML2_MAX_ELEMENT_DEPTH = 500;
 
 namespace tinyxml2
 {


### PR DESCRIPTION
The depth recursion limit TINYXML2_MAX_ELEMENT_DEPTH = 100 is quite restrictive for some applications. We encountered it [here](https://github.com/deepmind/mujoco/issues/307), where it is limiting our users from forming simulated chains with more than 100 joints ([here](https://github.com/deepmind/mujoco/issues/263#issuecomment-1128866926) is a video of a simulated chain, for illustration). While we of course accept that some limit is required for safety, we feel that 100 is too small.

This PR proposes to increase it to 500, which matches the depth allowed by other standard parsers, see e.g. [libxml2](https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/xpath.c#L131) and [IBM DataPower](https://www.ibm.com/docs/en/datapower-gateway/10.0.1?topic=20-json-parser-limits).

Thanks for your time and consideration.