### PR TITLE
add FirstDescendantElement and LastDescendantElement functions

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1047,6 +1047,48 @@ const XMLElement* XMLNode::PreviousSiblingElement( const char* name ) const
 }
 
 
+const XMLElement* XMLNode::FirstDescendantElement(const char** names) const
+{
+    if (!names || !*names)
+    {
+        return 0;
+    }
+
+    const XMLNode* node = this;
+    for (const char** ptr = names; *ptr; ptr++)
+    {
+        node = node->FirstChildElement((**ptr) ? *ptr : 0);
+        if (!node)
+        {
+            return 0;
+        }
+    }
+
+    return (XMLElement*)node;
+}
+
+
+const XMLElement* XMLNode::LastDescendantElement(const char** names) const
+{
+    if (!names || !*names)
+    {
+        return 0;
+    }
+
+    const XMLNode* node = this;
+    for (const char** ptr = names; *ptr; ptr++)
+    {
+        node = node->LastChildElement((**ptr) ? *ptr : 0);
+        if (!node)
+        {
+            return 0;
+        }
+    }
+
+    return (XMLElement*)node;
+}
+
+
 char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
 {
     // This is a recursive method, but thinking about it "at the current level"

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -833,6 +833,22 @@ public:
         return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->NextSiblingElement( name ) );
     }
 
+    /** Get the first descendant element with the specified list of name.
+    */
+    const XMLElement* FirstDescendantElement(const char** names) const;
+
+    XMLElement* FirstDescendantElement(const char** names) {
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->FirstDescendantElement(names));
+    }
+
+    /** Get the last descendant element with the specified list of name.
+    */
+    const XMLElement* LastDescendantElement(const char** names) const;
+
+    XMLElement* LastDescendantElement(const char** names) {
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->LastDescendantElement(names));
+    }
+
     /**
     	Add a child node as the last (right) child.
 		If the child node is already part of the document,


### PR DESCRIPTION
The normal way to find a descendent is FirstChildElement()->FirstChildElement()
But it lacks the null check, so I added the 2 functions to cover the null check.

The last string of the list should be null, and an empty string in the list matches any child,
example:
static const char* names[] = { "son", "grandson", nullptr };
FirstDescendantElement(names);

static const char* names[] = { "", "level2", nullptr };
FirstDescendantElement(names);