### PR TITLE
fix: fix symbol export on Windows + use target properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ target_compile_definitions(
 set_target_properties(
     tinyxml2
     PROPERTIES
-    DEFINE_SYMBOL "TINYXML2_EXPORT" # only used when BUILD_SHARED_LIBS is ON
+    DEFINE_SYMBOL "TINYXML2_EXPORT" # only used when tinyxml2_SHARED_LIBS/BUILD_SHARED_LIBS is ON
+
     VERSION "${tinyxml2_VERSION}"
     SOVERSION "${tinyxml2_VERSION_MAJOR}"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,6 @@ endif ()
 ## Main library build
 ##
 
-if (BUILD_SHARED_LIBS)
-    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-    set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
-endif()
-
 add_library(tinyxml2 tinyxml2.cpp tinyxml2.h)
 add_library(tinyxml2::tinyxml2 ALIAS tinyxml2)
 
@@ -38,8 +33,9 @@ target_compile_definitions(
 set_target_properties(
     tinyxml2
     PROPERTIES
-    DEFINE_SYMBOL "TINYXML2_EXPORT" # only used when tinyxml2_SHARED_LIBS/BUILD_SHARED_LIBS is ON
-
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN YES
+    DEFINE_SYMBOL "TINYXML2_EXPORT" # used when tinyxml2_SHARED_LIBS or BUILD_SHARED_LIBS is ON
     VERSION "${tinyxml2_VERSION}"
     SOVERSION "${tinyxml2_VERSION_MAJOR}"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,13 +38,10 @@ target_compile_definitions(
 set_target_properties(
     tinyxml2
     PROPERTIES
+    DEFINE_SYMBOL "TINYXML2_EXPORT" # only used when BUILD_SHARED_LIBS is ON
     VERSION "${tinyxml2_VERSION}"
     SOVERSION "${tinyxml2_VERSION_MAJOR}"
 )
-
-if(BUILD_SHARED_LIBS)
-    target_compile_definitions(tinyxml2 PRIVATE "TINYXML2_EXPORT")
-endif()
 
 if (tinyxml2_BUILD_TESTING)
     add_executable(xmltest xmltest.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,10 @@ endif ()
 ## Main library build
 ##
 
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
+if (BUILD_SHARED_LIBS)
+    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+    set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
+endif()
 
 add_library(tinyxml2 tinyxml2.cpp tinyxml2.h)
 add_library(tinyxml2::tinyxml2 ALIAS tinyxml2)
@@ -36,10 +38,13 @@ target_compile_definitions(
 set_target_properties(
     tinyxml2
     PROPERTIES
-    DEFINE_SYMBOL "TINYXML2_EXPORT"
     VERSION "${tinyxml2_VERSION}"
     SOVERSION "${tinyxml2_VERSION_MAJOR}"
 )
+
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(tinyxml2 PRIVATE "TINYXML2_EXPORT")
+endif()
 
 if (tinyxml2_BUILD_TESTING)
     add_executable(xmltest xmltest.cpp)

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -72,8 +72,7 @@ distribution.
 #   else
 #       define TINYXML2_LIB
 #   endif
-#endif
-#if defined(TINYXML2_EXPORT) && __GNUC__ >= 4
+#elif defined(TINYXML2_EXPORT) && __GNUC__ >= 4
 #   define TINYXML2_LIB __attribute__((visibility("default")))
 #else
 #   define TINYXML2_LIB

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -72,7 +72,8 @@ distribution.
 #   else
 #       define TINYXML2_LIB
 #   endif
-#elif __GNUC__ >= 4
+#endif
+#if defined(TINYXML2_EXPORT) && __GNUC__ >= 4
 #   define TINYXML2_LIB __attribute__((visibility("default")))
 #else
 #   define TINYXML2_LIB


### PR DESCRIPTION
This changes the export definition to only happen when the tinyxml2 itself is built as a shared library.

It fixes an issue where the tinyxml2 symbols are exported even when it is compiled statically and privately linked into another shared library. This allows the compiler to inline these symbols. Otherwise, the symbols of tinyxml2 are exported in the final shared library.