### PR TITLE
Added ChildElementCount()

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -822,6 +822,34 @@ XMLNode::~XMLNode()
     }
 }
 
+// ChildElementCount was originally suggested by msteiger on the sourceforge page for TinyXML and modified by KB1SPH for TinyXML-2.
+
+int XMLNode::ChildElementCount(const char *value) const {
+	int count = 0;
+
+	const XMLElement *e = FirstChildElement(value);
+
+	while (e) {
+		e = e->NextSiblingElement(value);
+		count++;
+	}
+
+	return count;
+}
+
+int XMLNode::ChildElementCount() const {
+	int count = 0;
+
+	const XMLElement *e = FirstChildElement();
+
+	while (e) {
+		e = e->NextSiblingElement();
+		count++;
+	}
+
+	return count;
+}
+
 const char* XMLNode::Value() const
 {
     // Edge case: XMLDocuments don't have a Value. Return null.

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -732,6 +732,12 @@ public:
         return 0;
     }
 
+    // ChildElementCount was originally suggested by msteiger on the sourceforge page for TinyXML and modified by KB1SPH for TinyXML-2.
+
+    int ChildElementCount(const char *value) const;
+
+    int ChildElementCount() const;
+
     /** The meaning of 'value' changes for the specific type.
     	@verbatim
     	Document:	empty (NULL is returned, not an empty string)


### PR DESCRIPTION
Added ChildElementCount() to get a count of child elements easier.  Originally suggested by msteiger on sourceforge for original tinyxml.