### PR TITLE
Add support for QNX 7.1 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,17 @@ if (tinyxml2_BUILD_TESTING)
     )
 
     set_tests_properties(xmltest PROPERTIES PASS_REGULAR_EXPRESSION ", Fail 0")
+
+    if (QNX)
+        install(
+            TARGETS xmltest
+            DESTINATION bin/tinyxml2_tests
+        )
+        install(
+            DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/resources
+            DESTINATION bin/tinyxml2_tests
+        )
+    endif ()
 endif ()
 
 ##

--- a/build_qnx/Makefile
+++ b/build_qnx/Makefile
@@ -1,0 +1,8 @@
+LIST=OS
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/common.mk
+++ b/build_qnx/common.mk
@@ -1,0 +1,90 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+NAME=tinyxml2
+
+DIST_BASE=$(PRODUCT_ROOT)
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+tinyxml2_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+tinyxml2_VERSION = 9.0.0
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+#set the following to FALSE if generating .pinfo files is causing problems
+GENERATE_PINFO_FILES ?= TRUE
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = tinyxml2_all
+.PHONY: tinyxml2_all install check clean
+
+CFLAGS += $(FLAGS)
+LDFLAGS += -Wl,--build-id=md5
+
+define PINFO
+endef
+PINFO_STATE=Experimental
+USEFILE=
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_PREFIX=$(tinyxml2_INSTALL_ROOT)/$(CPUVARDIR)/usr \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DCMAKE_SYSTEM_PROCESSOR=$(CPUVARDIR) \
+             -DCMAKE_INSTALL_LIBDIR=$(QNX_TARGET)/$(CPUVARDIR)/usr/lib \
+             -DCMAKE_INSTALL_INCLUDEDIR=$(QNX_TARGET)/usr/include/tinyxml2 \
+             -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_ASM_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DBUILD_SHARED_LIBS=1 \
+             -DBUILD_TESTING=OFF
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
+
+ifndef NO_TARGET_OVERRIDE
+tinyxml2_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(DIST_BASE)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install check: tinyxml2_all
+	@echo Installing...
+	@cd build && make VERBOSE=1 install $(MAKE_ARGS)
+	@echo Done.
+
+install_test: install
+	@mkdir -p build_tests
+	@cd build_tests && cmake $(CMAKE_ARGS) $(DIST_BASE)/test
+	@cd build_tests && make VERBOSE=1 install $(MAKE_ARGS)
+
+clean iclean spotless:
+	rm -rf build
+	rm -rf build_tests
+
+uninstall:
+endif
+
+#everything down below deals with the generation of the PINFO
+#information for shared objects that is used by the QNX build
+#infrastructure to embed metadata in the .so files, for example
+#data and time, version number, description, etc. Metadata can
+#be retrieved on the target by typing 'use -i <path to openblas .so file>'.
+#this is optional: setting GENERATE_PINFO_FILES to FALSE will disable
+#the insertion of metadata in .so files.
+ifeq ($(GENERATE_PINFO_FILES), TRUE)
+#the following rules are called by the cmake generated makefiles,
+#in order to generate the .pinfo files for the shared libraries
+%.so$(tinyxml2_VERSION):
+	$(ADD_PINFO)
+	$(ADD_USAGE)
+
+endif

--- a/build_qnx/nto/Makefile
+++ b/build_qnx/nto/Makefile
@@ -1,0 +1,8 @@
+LIST=CPU
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/aarch64/Makefile
+++ b/build_qnx/nto/aarch64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/aarch64/so.le/Makefile
+++ b/build_qnx/nto/aarch64/so.le/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build_qnx/nto/x86_64/Makefile
+++ b/build_qnx/nto/x86_64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/x86_64/so/Makefile
+++ b/build_qnx/nto/x86_64/so/Makefile
@@ -1,0 +1,1 @@
+include ../../../common.mk

--- a/build_qnx/qnx.nto.toolchain.cmake
+++ b/build_qnx/qnx.nto.toolchain.cmake
@@ -1,0 +1,34 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_ASM_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} -std=gnu++11 ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_ASM_FLAGS}" CACHE STRING "asm_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -51,7 +51,13 @@ bool XMLTest (const char* testString, const char* expected, const char* found, b
 			printf( "%s\n", found );
 		}
 		else {
+#ifdef __QNXNTO__
+			const char* expected_qnx = expected == NULL ? "(null)" : expected;
+			const char* found_qnx = found == NULL ? "(null)" : expected;
+			printf (" %s [%s][%s]\n", testString, expected_qnx, found_qnx);
+#else
 			printf (" %s [%s][%s]\n", testString, expected, found);
+#endif
 		}
 	}
 


### PR DESCRIPTION
Add support for QNX 7.1 build.

Build instruction:
```bash
# Source the QNX environment script
source <path-to-qnxsdp-env.sh>/qnxsdp-env.sh

# Clone the repo
git clone https://github.com/chachoi/tinyxml2.git && cd tinyxml2/build_qnx

# Build and install
make -j 4 install
```
To build xmltest, set BUILD_TESTING to ON in build_qnx/common.mk.

Headers will be installed to ${QNX_TARGET}/usr/include
Libraries will be installed to ${QNX_TARGET}/${CPUVARDIR}/usr/lib
xmltest will be installed to ${QNX_TARGET}/${CPUVARDIR}/usr/bin/tinyxml2_tests

To run xmltest, simply move tinyxml2_tests folder and the tinyxml2 library to a QNX target:
```bash
scp $QNX_TARGET/aarch64le/usr/lib/libtinyxml2* root@<target-ip-address>:/usr/lib
scp -r $QNX_TARGET/aarch64le/usr/bin/tinyxml2_tests root@<target-ip-address>:/var
```

And ssh into the QNX target and run xmltest:
```bash
ssh root@<target-ip-address>
cd /var/tinyxml2_tests
./xmltest
```

All 465 tests pass on QNX currently.