### PR TITLE
Remove LFS64 calls and set _FILE_OFFSET_BITS=64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ target_compile_definitions(
     PUBLIC $<$<CONFIG:Debug>:TINYXML2_DEBUG>
     INTERFACE $<$<BOOL:${BUILD_SHARED_LIBS}>:TINYXML2_IMPORT>
     PRIVATE $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
+    PUBLIC _FILE_OFFSET_BITS=64
 )
 
 set_target_properties(

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ARFLAGS = cr
 RM = rm -f
 RANLIB = ranlib
 MKDIR = mkdir -p
-CXXFLAGS = -fPIC
+CXXFLAGS = -D_FILE_OFFSET_BITS=64 -fPIC
 
 INSTALL = install
 INSTALL_PROGRAM = $(INSTALL)

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -114,9 +114,6 @@ distribution.
         #define TIXML_FSEEK fseeko
         #define TIXML_FTELL ftello
     #endif
-#elif defined(__unix__) && defined(__x86_64__)
-	#define TIXML_FSEEK fseeko64
-	#define TIXML_FTELL ftello64
 #else
 	#define TIXML_FSEEK fseek
 	#define TIXML_FTELL ftell


### PR DESCRIPTION
Musl 1.2.4 made the LFS64 interfaces only available when _LARGEFILE64_SOURCE is defined, and they will be removed altogether in Musl 1.2.5. This commit replaces the LFS64 calls with their non-LFS64 versions and defines _FILE_OFFSET_BITS=64, which makes all interfaces 64-bit.

Bug: https://bugs.gentoo.org/905999