### PR TITLE
fix compiler detection

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -64,7 +64,7 @@ distribution.
 #   pragma warning(disable: 4251)
 #endif
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #   ifdef TINYXML2_EXPORT
 #       define TINYXML2_LIB __declspec(dllexport)
 #   elif defined(TINYXML2_IMPORT)


### PR DESCRIPTION
`_WIN32` is used for detection Windows. MinGW also defines it, and then causes error.