### PR TITLE
Bazel module configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,14 @@
+########################################
+# Bzlmod Configuration
+########################################
+
+# Uncomment to build with bzlmod (i.e. use MODULE.bazel) or
+# use --enable_bzlmod on the command line.
+common --enable_bzlmod
+
+########################################
+# Bazel Configuration
+########################################
+
+# https://bazel.build/docs/user-manual#verbose-failures
+build --verbose_failures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,3 +109,10 @@ jobs:
           --build-generator Ninja
           --build-options -DCMAKE_BUILD_TYPE=Release -Dtinyxml2_SHARED_LIBS=YES -DCMAKE_PREFIX_PATH=${{github.workspace}}/install
           --test-command ctest --output-on-failure
+
+      # Bazel
+      - name: "Bazel Build"
+        run: bazel build //...
+
+      - name: "Bazel Test"
+        run: bazel test //...

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ tinyxml2/temp/
 libtinyxml2.a
 xmltest
 vs/debug
-
+bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,21 @@
+
+cc_library(
+    name = "tinyxml2",
+    srcs = ["tinyxml2.cpp"],
+    hdrs = ["tinyxml2.h"],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "xmltest",
+    srcs = ["xmltest.cpp"],
+    size = "small",
+    data = 
+        glob(["resources/*.xml"]) + # Input files
+        [ "resources/out/readme.txt" ], # Hack to create output dir
+    visibility = ["//visibility:private"],
+    deps = [
+        ":tinyxml2"
+    ]
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,11 @@
+"""
+Welcome to TinyXML2!
+"""
+
+module(
+    name = "tinyxml2",
+    compatibility_level = 1,
+    version = "9.0.0",
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.8")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,1 @@
+workspace(name = "tinyxml2")

--- a/readme.md
+++ b/readme.md
@@ -281,6 +281,14 @@ You can download and install TinyXML-2 using the [vcpkg](https://github.com/Micr
 
 The TinyXML-2 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
+Building TinyXML-2 - Using Bazel
+--------------------------------
+
+```
+bazel build //...
+bazel test //...
+```
+
 Versioning
 ----------
 


### PR DESCRIPTION
This paves the way for a bazel build, module style (with the goal of then publishing it on the [bazel-central-registry](https://github.com/bazelbuild/bazel-central-registry)).

* [x] A `MODULE.bazel` with package and dependency information
* [x] A `BUILD.bazel` with build and test rules
* [x] A github action task that builds and tests
* [x] A small section in the readme indicating it can be built with bazel

