### PR TITLE
fixed `knownConditionTrueFalse` Cppcheck warning

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -531,12 +531,7 @@ const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
         }
         else {
             // Decimal.
-            const char* q = p+2;
-            if ( !(*q) ) {
-                return 0;
-            }
-
-            q = strchr( q, SEMICOLON );
+            const char* q = strchr( p+2, SEMICOLON );
 
             if ( !q ) {
                 return 0;


### PR DESCRIPTION
`*(p+2)` is already checked in the preceding if-condition, so it is redundant