### PR TITLE
Wrap 'callfopen' function with 'TINYXML2_FILE_SUPPORT' to ensure consistency

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2320,6 +2320,7 @@ XMLUnknown* XMLDocument::NewUnknown( const char* str )
     return unk;
 }
 
+#if TINYXML2_FILE_SUPPORT
 static FILE* callfopen( const char* filepath, const char* mode )
 {
     TIXMLASSERT( filepath );
@@ -2335,6 +2336,7 @@ static FILE* callfopen( const char* filepath, const char* mode )
 #endif
     return fp;
 }
+#endif
 
 void XMLDocument::DeleteNode( XMLNode* node )	{
     TIXMLASSERT( node );


### PR DESCRIPTION
The 'callfopen' function, used for opening files, is now wrapped with the 'TINYXML2_FILE_SUPPORT' preprocessor directive. This change aligns with the usage in 'LoadFile' and 'SaveFile' functions, which are also wrapped with 'TINYXML2_FILE_SUPPORT'. This ensures that the function is only compiled and used when file support is enabled, providing consistency across the codebase.
