### PR TITLE
Fix format error of TIXML_SNPRINTF

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2518,7 +2518,8 @@ void XMLDocument::SetError( XMLError error, int lineNum, const char* format, ...
     char* buffer = new char[BUFFER_SIZE];
 
     TIXMLASSERT(sizeof(error) <= sizeof(int));
-    TIXML_SNPRINTF(buffer, BUFFER_SIZE, "Error=%s ErrorID=%d (0x%x) Line number=%d", ErrorIDToName(error), int(error), int(error), lineNum);
+    TIXML_SNPRINTF(buffer, BUFFER_SIZE, "Error=%s ErrorID=%d (0x%x) Line number=%d",
+        ErrorIDToName(error), static_cast<int>(error), static_cast<unsigned int>(error), lineNum);
 
 	if (format) {
 		size_t len = strlen(buffer);


### PR DESCRIPTION
The format "%x" is treated as an unsigned int by the GCC compiler. Use static_cast to cast the error to an unsigned int to match the "%x" type. Additionally, replace int(error) with static_cast<int>(error) to avoid the old-style cast warning.
