### PR TITLE
Use fseek/ftell on Android when api level < 24

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -106,14 +106,9 @@ distribution.
 #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
 	#define TIXML_FSEEK fseeko
 	#define TIXML_FTELL ftello
-#elif defined(__ANDROID__) 
-    #if __ANDROID_API__ > 24
-        #define TIXML_FSEEK fseeko64
-        #define TIXML_FTELL ftello64
-    #else
-        #define TIXML_FSEEK fseeko
-        #define TIXML_FTELL ftello
-    #endif
+#elif defined(__ANDROID__) && __ANDROID_API__ > 24
+	#define TIXML_FSEEK fseeko64
+	#define TIXML_FTELL ftello64
 #else
 	#define TIXML_FSEEK fseek
 	#define TIXML_FTELL ftell


### PR DESCRIPTION
Android only supports fseeko+ftello (and their 64-bit versions) for API level 24 and above.

Tested using:
cmake -Bbuild -DCMAKE_TOOLCHAIN_FILE=~/Library/Android/sdk/ndk/26.0.10792818/build/cmake/android.toolchain.cmake -DANDROID_ABI=armeabi-v7a -DANDROID_PLATFORM=android-22 .
cmake --build build

Failed with:
tinyxml2/tinyxml2.cpp:2380:5: error: use of undeclared identifier 'fseeko'; did you mean 'fseek'?
.../Library/Android/sdk/ndk/26.0.10792818/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h:215:5: note: 'fseek' declared here
tinyxml2/tinyxml2.cpp:2390:44: error: use of undeclared identifier 'ftello'; did you mean 'ftell'?
.../Library/Android/sdk/ndk/26.0.10792818/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h:216:6: note: 'ftell' declared here