### PR TITLE
Fix format specifier mismatch in XMLUtil::ToStr

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -605,7 +605,7 @@ void XMLUtil::ToStr( int64_t v, char* buffer, int bufferSize )
 void XMLUtil::ToStr( uint64_t v, char* buffer, int bufferSize )
 {
     // horrible syntax trick to make the compiler happy about %llu
-    TIXML_SNPRINTF(buffer, bufferSize, "%llu", (long long)v);
+    TIXML_SNPRINTF(buffer, bufferSize, "%llu", static_cast<unsigned long long>(v));
 }
 
 bool XMLUtil::ToInt(const char* str, int* value)


### PR DESCRIPTION
In the XMLUtil::ToStr( uint64_t v, char* buffer, int bufferSize ) function, the format specifier %llu was used with a signed long long argument. This caused a type mismatch warning. The argument has been changed to unsigned long long to match the format specifier, resolving the warning.