### PR TITLE
Initialize _pool array in tinyxml2.h

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -314,7 +314,7 @@ private:
     }
 
     T*  _mem;
-    T   _pool[static_cast<size_t>(INITIAL_SIZE)];
+    T   _pool[static_cast<size_t>(INITIAL_SIZE)] = {};
     int _allocated;		// objects allocated
     int _size;			// number objects in use
 };


### PR DESCRIPTION
Added {} to the declaration of the _pool array in the tinyxml2.h file. This ensures that all elements of the _pool array are initialized to their default values. This change improves the safety and predictability of the code by preventing uninitialized values.