### PR TITLE
Update QueryIntValue and QueryUnsignedValue to use int32_t and uint32_t types for better consistency.

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -635,7 +635,7 @@ bool XMLUtil::ToUnsigned(const char* str, unsigned* value)
 
 bool XMLUtil::ToBool( const char* str, bool* value )
 {
-    int ival = 0;
+	int32_t ival = 0;
     if ( ToInt( str, &ival )) {
         *value = (ival==0) ? false : true;
         return true;

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1644,16 +1644,16 @@ const char* XMLElement::Attribute( const char* name, const char* value ) const
     return 0;
 }
 
-int XMLElement::IntAttribute(const char* name, int defaultValue) const
+int32_t XMLElement::IntAttribute(const char* name, int defaultValue) const
 {
-	int i = defaultValue;
+	int32_t i = defaultValue;
 	QueryIntAttribute(name, &i);
 	return i;
 }
 
-unsigned XMLElement::UnsignedAttribute(const char* name, unsigned defaultValue) const
+uint32_t XMLElement::UnsignedAttribute(const char* name, unsigned defaultValue) const
 {
-	unsigned i = defaultValue;
+	uint32_t i = defaultValue;
 	QueryUnsignedAttribute(name, &i);
 	return i;
 }

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1869,14 +1869,14 @@ XMLError XMLElement::QueryFloatText( float* fval ) const
 
 int XMLElement::IntText(int defaultValue) const
 {
-	int i = defaultValue;
+	int32_t i = defaultValue;
 	QueryIntText(&i);
 	return i;
 }
 
 unsigned XMLElement::UnsignedText(unsigned defaultValue) const
 {
-	unsigned i = defaultValue;
+	uint32_t i = defaultValue;
 	QueryUnsignedText(&i);
 	return i;
 }

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -618,7 +618,7 @@ bool XMLUtil::ToInt(const char* str, int* value)
         }
     }
     else {
-        if (TIXML_SSCANF(str, "%d", value) == 1) {
+        if (TIXML_SSCANF(str, "%ld", value) == 1) {
             return true;
         }
     }
@@ -627,7 +627,7 @@ bool XMLUtil::ToInt(const char* str, int* value)
 
 bool XMLUtil::ToUnsigned(const char* str, unsigned* value)
 {
-    if (TIXML_SSCANF(str, IsPrefixHex(str) ? "%x" : "%u", value) == 1) {
+    if (TIXML_SSCANF(str, IsPrefixHex(str) ? "%x" : "%lu", value) == 1) {
         return true;
     }
     return false;

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2777,7 +2777,7 @@ void XMLPrinter::PushAttribute( const char* name, const char* value )
 }
 
 
-void XMLPrinter::PushAttribute( const char* name, int v )
+void XMLPrinter::PushAttribute( const char* name, int32_t v )
 {
     char buf[BUF_SIZE];
     XMLUtil::ToStr( v, buf, BUF_SIZE );
@@ -2785,7 +2785,7 @@ void XMLPrinter::PushAttribute( const char* name, int v )
 }
 
 
-void XMLPrinter::PushAttribute( const char* name, unsigned v )
+void XMLPrinter::PushAttribute( const char* name, uint32_t v )
 {
     char buf[BUF_SIZE];
     XMLUtil::ToStr( v, buf, BUF_SIZE );

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1777,7 +1777,7 @@ void XMLElement::SetText( double v )
 }
 
 
-XMLError XMLElement::QueryIntText( int* ival ) const
+XMLError XMLElement::QueryIntText( int32_t* ival ) const
 {
     if ( FirstChild() && FirstChild()->ToText() ) {
         const char* t = FirstChild()->Value();
@@ -1790,7 +1790,7 @@ XMLError XMLElement::QueryIntText( int* ival ) const
 }
 
 
-XMLError XMLElement::QueryUnsignedText( unsigned* uval ) const
+XMLError XMLElement::QueryUnsignedText( uint32_t* uval ) const
 {
     if ( FirstChild() && FirstChild()->ToText() ) {
         const char* t = FirstChild()->Value();

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1481,7 +1481,7 @@ void XMLAttribute::SetName( const char* n )
 }
 
 
-XMLError XMLAttribute::QueryIntValue( int* value ) const
+XMLError XMLAttribute::QueryIntValue( int32_t* value ) const
 {
     if ( XMLUtil::ToInt( Value(), value )) {
         return XML_SUCCESS;
@@ -1490,7 +1490,7 @@ XMLError XMLAttribute::QueryIntValue( int* value ) const
 }
 
 
-XMLError XMLAttribute::QueryUnsignedValue( unsigned int* value ) const
+XMLError XMLAttribute::QueryUnsignedValue( uint32_t* value ) const
 {
     if ( XMLUtil::ToUnsigned( Value(), value )) {
         return XML_SUCCESS;

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -565,13 +565,13 @@ const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
 
 void XMLUtil::ToStr( int32_t v, char* buffer, int bufferSize )
 {
-    TIXML_SNPRINTF( buffer, bufferSize, "%d", v );
+    TIXML_SNPRINTF( buffer, bufferSize, "%ld", v );
 }
 
 
 void XMLUtil::ToStr( uint32_t v, char* buffer, int bufferSize )
 {
-    TIXML_SNPRINTF( buffer, bufferSize, "%u", v );
+    TIXML_SNPRINTF( buffer, bufferSize, "%lu", v );
 }
 
 

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2895,7 +2895,7 @@ void XMLPrinter::PushText( uint64_t value )
 }
 
 
-void XMLPrinter::PushText( int value )
+void XMLPrinter::PushText( int32_t value )
 {
     char buf[BUF_SIZE];
     XMLUtil::ToStr( value, buf, BUF_SIZE );
@@ -2903,7 +2903,7 @@ void XMLPrinter::PushText( int value )
 }
 
 
-void XMLPrinter::PushText( unsigned value )
+void XMLPrinter::PushText( uint32_t value )
 {
     char buf[BUF_SIZE];
     XMLUtil::ToStr( value, buf, BUF_SIZE );

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1550,7 +1550,7 @@ void XMLAttribute::SetAttribute( const char* v )
 }
 
 
-void XMLAttribute::SetAttribute( int v )
+void XMLAttribute::SetAttribute( int32_t v )
 {
     char buf[BUF_SIZE];
     XMLUtil::ToStr( v, buf, BUF_SIZE );
@@ -1558,7 +1558,7 @@ void XMLAttribute::SetAttribute( int v )
 }
 
 
-void XMLAttribute::SetAttribute( unsigned v )
+void XMLAttribute::SetAttribute( uint32_t v )
 {
     char buf[BUF_SIZE];
     XMLUtil::ToStr( v, buf, BUF_SIZE );

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -1723,7 +1723,7 @@ void	XMLElement::SetText( const char* inText )
 }
 
 
-void XMLElement::SetText( int v )
+void XMLElement::SetText( int32_t v )
 {
     char buf[BUF_SIZE];
     XMLUtil::ToStr( v, buf, BUF_SIZE );
@@ -1731,7 +1731,7 @@ void XMLElement::SetText( int v )
 }
 
 
-void XMLElement::SetText( unsigned v )
+void XMLElement::SetText( uint32_t v )
 {
     char buf[BUF_SIZE];
     XMLUtil::ToStr( v, buf, BUF_SIZE );

--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -563,13 +563,13 @@ const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
 }
 
 
-void XMLUtil::ToStr( int v, char* buffer, int bufferSize )
+void XMLUtil::ToStr( int32_t v, char* buffer, int bufferSize )
 {
     TIXML_SNPRINTF( buffer, bufferSize, "%d", v );
 }
 
 
-void XMLUtil::ToStr( unsigned v, char* buffer, int bufferSize )
+void XMLUtil::ToStr( uint32_t v, char* buffer, int bufferSize )
 {
     TIXML_SNPRINTF( buffer, bufferSize, "%u", v );
 }

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1226,9 +1226,9 @@ public:
     /// Set the attribute to a string value.
     void SetAttribute( const char* value );
     /// Set the attribute to value.
-    void SetAttribute( int value );
+    void SetAttribute(int32_t value );
     /// Set the attribute to value.
-    void SetAttribute( unsigned value );
+    void SetAttribute( uint32_t value );
 	/// Set the attribute to value.
 	void SetAttribute(int64_t value);
     /// Set the attribute to value.

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1343,7 +1343,7 @@ public:
     	QueryIntAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
     	@endverbatim
     */
-    XMLError QueryIntAttribute( const char* name, int* value ) const				{
+    XMLError QueryIntAttribute( const char* name, int32_t* value ) const				{
         const XMLAttribute* a = FindAttribute( name );
         if ( !a ) {
             return XML_NO_ATTRIBUTE;
@@ -1352,7 +1352,7 @@ public:
     }
 
 	/// See QueryIntAttribute()
-    XMLError QueryUnsignedAttribute( const char* name, unsigned int* value ) const	{
+    XMLError QueryUnsignedAttribute( const char* name, uint32_t* value ) const	{
         const XMLAttribute* a = FindAttribute( name );
         if ( !a ) {
             return XML_NO_ATTRIBUTE;

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1316,9 +1316,9 @@ public:
         or if there is an error. (For a method with error
     	checking, see QueryIntAttribute()).
     */
-	int IntAttribute(const char* name, int defaultValue = 0) const;
+    int32_t IntAttribute(const char* name, int defaultValue = 0) const;
     /// See IntAttribute()
-	unsigned UnsignedAttribute(const char* name, unsigned defaultValue = 0) const;
+    uint32_t UnsignedAttribute(const char* name, unsigned defaultValue = 0) const;
 	/// See IntAttribute()
 	int64_t Int64Attribute(const char* name, int64_t defaultValue = 0) const;
     /// See IntAttribute()

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1162,8 +1162,8 @@ public:
         If the value isn't an integer, 0 will be returned. There is no error checking;
     	use QueryIntValue() if you need error checking.
     */
-	int	IntValue() const {
-		int i = 0;
+    int32_t IntValue() const {
+    	int32_t i = 0;
 		QueryIntValue(&i);
 		return i;
 	}
@@ -1181,8 +1181,8 @@ public:
     }
 
     /// Query as an unsigned integer. See IntValue()
-    unsigned UnsignedValue() const			{
-        unsigned i=0;
+    uint32_t UnsignedValue() const			{
+    	uint32_t i=0;
         QueryUnsignedValue( &i );
         return i;
     }

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2270,9 +2270,9 @@ public:
     /// Add a text node.
     void PushText( const char* text, bool cdata=false );
     /// Add a text node from an integer.
-    void PushText( int value );
+    void PushText( int32_t value );
     /// Add a text node from an unsigned.
-    void PushText( unsigned value );
+    void PushText( uint32_t value );
 	/// Add a text node from a signed 64bit integer.
 	void PushText( int64_t value );
 	/// Add a text node from an unsigned 64bit integer.

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1432,11 +1432,11 @@ public:
     	QueryAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
     	@endverbatim
     */
-	XMLError QueryAttribute( const char* name, int* value ) const {
+	XMLError QueryAttribute( const char* name, int32_t* value ) const {
 		return QueryIntAttribute( name, value );
 	}
 
-	XMLError QueryAttribute( const char* name, unsigned int* value ) const {
+	XMLError QueryAttribute( const char* name, uint32_t* value ) const {
 		return QueryUnsignedAttribute( name, value );
 	}
 

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2258,8 +2258,8 @@ public:
     void OpenElement( const char* name, bool compactMode=false );
     /// If streaming, add an attribute to an open element.
     void PushAttribute( const char* name, const char* value );
-    void PushAttribute( const char* name, int value );
-    void PushAttribute( const char* name, unsigned value );
+    void PushAttribute( const char* name, int32_t value );
+    void PushAttribute( const char* name, uint32_t value );
 	void PushAttribute( const char* name, int64_t value );
 	void PushAttribute( const char* name, uint64_t value );
 	void PushAttribute( const char* name, bool value );

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1470,12 +1470,12 @@ public:
         a->SetAttribute( value );
     }
     /// Sets the named attribute to value.
-    void SetAttribute( const char* name, int value )			{
+    void SetAttribute( const char* name, int32_t value )			{
         XMLAttribute* a = FindOrCreateAttribute( name );
         a->SetAttribute( value );
     }
     /// Sets the named attribute to value.
-    void SetAttribute( const char* name, unsigned value )		{
+    void SetAttribute( const char* name, uint32_t value )		{
         XMLAttribute* a = FindOrCreateAttribute( name );
         a->SetAttribute( value );
     }

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1586,9 +1586,9 @@ public:
     */
 	void SetText( const char* inText );
     /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( int value );
+    void SetText( int32_t value );
     /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( unsigned value );
+    void SetText( uint32_t value );
 	/// Convenience method for setting text inside an element. See SetText() for important limitations.
 	void SetText(int64_t value);
     /// Convenience method for setting text inside an element. See SetText() for important limitations.

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1209,9 +1209,9 @@ public:
     	in the provided parameter. The function will return XML_SUCCESS on success,
     	and XML_WRONG_ATTRIBUTE_TYPE if the conversion is not successful.
     */
-    XMLError QueryIntValue( int* value ) const;
+    XMLError QueryIntValue( int32_t* value ) const;
     /// See QueryIntValue
-    XMLError QueryUnsignedValue( unsigned int* value ) const;
+    XMLError QueryUnsignedValue( uint32_t* value ) const;
 	/// See QueryIntValue
 	XMLError QueryInt64Value(int64_t* value) const;
     /// See QueryIntValue

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -614,8 +614,8 @@ public:
     static void ConvertUTF32ToUTF8( unsigned long input, char* output, int* length );
 
     // converts primitive types to strings
-    static void ToStr( int v, char* buffer, int bufferSize );
-    static void ToStr( unsigned v, char* buffer, int bufferSize );
+    static void ToStr( int32_t v, char* buffer, int bufferSize );
+    static void ToStr( uint32_t v, char* buffer, int bufferSize );
     static void ToStr( bool v, char* buffer, int bufferSize );
     static void ToStr( float v, char* buffer, int bufferSize );
     static void ToStr( double v, char* buffer, int bufferSize );
@@ -623,8 +623,8 @@ public:
     static void ToStr(uint64_t v, char* buffer, int bufferSize);
 
     // converts strings to primitive types
-    static bool	ToInt( const char* str, int* value );
-    static bool ToUnsigned( const char* str, unsigned* value );
+    static bool	ToInt( const char* str, int32_t* value );
+    static bool ToUnsigned( const char* str, uint32_t* value );
     static bool	ToBool( const char* str, bool* value );
     static bool	ToFloat( const char* str, float* value );
     static bool ToDouble( const char* str, double* value );

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -1626,9 +1626,9 @@ public:
     			 to the requested type, and XML_NO_TEXT_NODE if there is no child text to query.
 
     */
-    XMLError QueryIntText( int* ival ) const;
+    XMLError QueryIntText( int32_t* ival ) const;
     /// See QueryIntText()
-    XMLError QueryUnsignedText( unsigned* uval ) const;
+    XMLError QueryUnsignedText( uint32_t* uval ) const;
 	/// See QueryIntText()
 	XMLError QueryInt64Text(int64_t* uval) const;
 	/// See QueryIntText()


### PR DESCRIPTION
fix #982