### PR TITLE
Add support for QNX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,17 @@ if (tinyxml2_BUILD_TESTING)
     set_tests_properties(xmltest PROPERTIES PASS_REGULAR_EXPRESSION ", Fail 0")
 endif ()
 
+if (QNX)
+    install(
+        TARGETS xmltest
+        DESTINATION bin/tinyxml2_tests
+    )
+    install(
+        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/resources
+        DESTINATION bin/tinyxml2_tests
+    )
+endif ()
+
 ##
 ## Installation
 ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,17 +55,6 @@ if (tinyxml2_BUILD_TESTING)
     set_tests_properties(xmltest PROPERTIES PASS_REGULAR_EXPRESSION ", Fail 0")
 endif ()
 
-if (QNX)
-    install(
-        TARGETS xmltest
-        DESTINATION bin/tinyxml2_tests
-    )
-    install(
-        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/resources
-        DESTINATION bin/tinyxml2_tests
-    )
-endif ()
-
 ##
 ## Installation
 ##
@@ -139,3 +128,14 @@ install(
     DESTINATION "${tinyxml2_INSTALL_PKGCONFIGDIR}"
     COMPONENT tinyxml2_development
 )
+
+if (QNX)
+    install(
+        TARGETS xmltest
+        DESTINATION bin/tinyxml2_tests
+    )
+    install(
+        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/resources
+        DESTINATION bin/tinyxml2_tests
+    )
+endif ()

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -24,7 +24,7 @@ distribution.
 #ifndef TINYXML2_INCLUDED
 #define TINYXML2_INCLUDED
 
-#if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__)
+#if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNX__)
 #   include <ctype.h>
 #   include <limits.h>
 #   include <stdio.h>

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -51,7 +51,13 @@ bool XMLTest (const char* testString, const char* expected, const char* found, b
 			printf( "%s\n", found );
 		}
 		else {
+#ifdef __QNX__
+			const char* expected_qnx = expected == NULL ? "(null)" : expected;
+			const char* found_qnx = found == NULL ? "(null)" : expected;
+			printf (" %s [%s][%s]\n", testString, expected_qnx, found_qnx);
+#else
 			printf (" %s [%s][%s]\n", testString, expected, found);
+#endif
 		}
 	}
 

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -51,7 +51,8 @@ bool XMLTest (const char* testString, const char* expected, const char* found, b
 			printf( "%s\n", found );
 		}
 		else {
-#ifdef __QNX__
+#ifndef __QNX__
+			// In QNX, null pointers cannot be printed as "(null)"
 			const char* expected_qnx = expected == NULL ? "(null)" : expected;
 			const char* found_qnx = found == NULL ? "(null)" : expected;
 			printf (" %s [%s][%s]\n", testString, expected_qnx, found_qnx);
@@ -2327,7 +2328,7 @@ int main( int argc, const char ** argv )
 		XMLTest( "Should be no error initially", false, doc.Error() );
 		doc.LoadFile( "resources/no-such-file.xml" );
 		XMLTest( "No such file - should fail", true, doc.Error() );
-                
+
 		doc.LoadFile("resources/dream.xml");
 		XMLTest("Error should be cleared", false, doc.Error());
 


### PR DESCRIPTION
Modifications:

- Change `__QNXNTO__` to `__QNX__` because `__QNXNTO__` is deprecated
- In xmltest.cpp, do not print nullptr because it would crash in QNX
- Install tests for QNX

Build and test instuction for QNX:
https://github.com/chachoi-world/qnx-ports/blob/main/tinyxml2/README.md

Thanks.