### PR TITLE
Add build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const lib = b.addStaticLibrary(.{
+        .name = "tinyxml2",
+        .target = target,
+        .optimize = optimize,
+    });
+    lib.linkLibCpp();
+
+    lib.addCSourceFiles(.{
+        .files = &.{"./tinyxml2.cpp"},
+    });
+    lib.installHeader(b.path("./tinyxml2.h"), "tinyxml2.h");
+    b.installArtifact(lib);
+
+    const test_exe = b.addExecutable(.{
+        .name = "xmltest",
+        .target = target,
+        .optimize = optimize,
+    });
+
+    test_exe.linkLibrary(lib);
+    test_exe.addCSourceFile(.{ .file = b.path("./xmltest.cpp") });
+
+    const run_tests = b.addRunArtifact(test_exe);
+    const test_step = b.step("test", "Build and run xmltest.");
+    test_step.dependOn(&run_tests.step);
+}


### PR DESCRIPTION
tinyxml2 is amazing and I want to use it in my Zig projects.

The best way for a Zig programmer to be able to do that is if tinyxml2 has a `build.zig` file in the source tree, which means downstream Zig users can use the package manager to easily integrate tinyxml2 into their projects.

Other benefits include:
- Another trivial way to build (`zig build` to build and `zig build test` to build and run the tests).
- Cross compilation for free (e.g. `zig build -Dtarget=arm-linux-muslabi`).

> (Additional build systems are costly to maintain, and tend to bit-rot. They are being removed over time.)

I completely get that. If this is deemed irrelevant, please just close the PR. For my own projects I can depend on my fork, but I thought I would contribute back as other Zig users might also want to use tinyxml2.

