### PR TITLE
fix tinyxml2 namespaces' ending comment

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2374,7 +2374,7 @@ private:
 };
 
 
-} // tinyxml2
+} // namespace tinyxml2
 
 #if defined(_MSC_VER)
 #   pragma warning(pop)

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2374,7 +2374,7 @@ private:
 };
 
 
-}	// tinyxml2
+} // tinyxml2
 
 #if defined(_MSC_VER)
 #   pragma warning(pop)


### PR DESCRIPTION
Several code analysers, like `clang-tidy`, report warnings on ending comment for tinyxml2 namespace. Here is a  clang-tidy 12.0.0 log fragment:
```text
../tinyxml2/tinyxml2.h:2377:2: warning: namespace 'tinyxml2' ends with an unrecognized comment [llvm-namespace-comment]
}       // tinyxml2
 ^~~~~~~~~~~~~~~~~~
  // namespace tinyxml2
../tinyxml2/tinyxml2.h:114:11: note: namespace 'tinyxml2' starts here
namespace tinyxml2
          ^
```
This pull request is aimed to fix the issue.