### PR TITLE
Make DocPrinter support DynArrays larger than 2G

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2314,7 +2314,7 @@ public:
     	of the XML file in memory. (Note the size returned
     	includes the terminating null.)
     */
-    int CStrSize() const {
+    size_t CStrSize() const {
         return _buffer.Size();
     }
     /**


### PR DESCRIPTION
If the DynArray within an XMLPrinter object carries 2 gigabytes of data or more, XMLPrinter::CStrSize returns a truncated result. If a program casts this back to size_t without thought, sign extension leads to bad things(tm).

```c++
int main()
{
	tinyxml2::XMLDocument doc;
	doc.InsertEndChild(doc.NewDeclaration());
	auto root = doc.NewElement("root");
	size_t sz = 0x80000002;
	auto blank = new char[sz];
	memset(blank, ' ', sz);
	blank[sz-1]='\0';
	root->SetText(blank);
	doc.InsertEndChild(root);
	tinyxml2::XMLPrinter printer(nullptr);
	doc.Print(&printer);
	std::string_view sv{printer.CStr(), static_cast<size_t>(printer.CStrSize())};
	// sv.size() is way too big, causing overflows on access
	std::string dup(sv); // boom
}
```

Fixes: 2.0.2-873-geb3ab0d