### PR TITLE
Fix: typo in the `XMLNode::DeepClone` description

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -891,7 +891,7 @@ public:
 
 		If the 'target' is null, then the nodes will
 		be allocated in the current document. If 'target'
-        is specified, the memory will be allocated is the
+        is specified, the memory will be allocated in the
         specified XMLDocument.
 
 		NOTE: This is probably not the correct tool to


### PR DESCRIPTION
There is a typo in the [`XMLNode::DeepClone`](https://github.com/leethomason/tinyxml2/blob/8a519a556afecb3e717a4797615a8bfa49cae10a/tinyxml2.h#L894) description (*"... the memory will be allocated **is** the specified XMLDocument."*). 

```C++
	/**
		Make a copy of this node and all its children.

		If the 'target' is null, then the nodes will
		be allocated in the current document. If 'target'
        is specified, the memory will be allocated is the
        specified XMLDocument.

		NOTE: This is probably not the correct tool to
		copy a document, since XMLDocuments can have multiple
		top level XMLNodes. You probably want to use
        XMLDocument::DeepCopy()
	*/
	XMLNode* DeepClone( XMLDocument* target ) const;
```

This pull request is aimed to fix it.

Thanks.