### PR TITLE
Fix ARM Compiler build errors

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -24,7 +24,7 @@ distribution.
 #include "tinyxml2.h"
 
 #include <new>		// yes, this one new style header, is in the Android SDK.
-#if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__)
+#if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__) || defined(__CC_ARM)
 #   include <stddef.h>
 #   include <stdarg.h>
 #else


### PR DESCRIPTION
Fix build errors on ARM Compiler 5 (DS-5) by treating the compiler like QNX, Borland C, and the Android NDK for purposes of system header includes.