### PR TITLE
Remove unnecessary assert >=0 on size_t

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -266,7 +266,6 @@ public:
     }
 
     size_t Size() const {
-        TIXMLASSERT( _size >= 0 );
         return _size;
     }
 


### PR DESCRIPTION
In it's current state it does not assert anything as size_t will always be 0 or positive but "-Wtype-limits" will complain about it "warning: comparison of unsigned expression in ‘>= 0’ is always true"