### PR TITLE
Optional Apos escaping

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2577,7 +2577,7 @@ void XMLDocument::PopDepth()
 	--_parsingDepth;
 }
 
-XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
+XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth, EscapeAposCharsInAttributes aposInAttributes ) :
     _elementJustOpened( false ),
     _stack(),
     _firstElement( true ),
@@ -2594,9 +2594,11 @@ XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
     }
     for( int i=0; i<NUM_ENTITIES; ++i ) {
         const char entityValue = entities[i].value;
-        const unsigned char flagIndex = static_cast<unsigned char>(entityValue);
-        TIXMLASSERT( flagIndex < ENTITY_RANGE );
-        _entityFlag[flagIndex] = true;
+        if ((aposInAttributes == ESCAPE_APOS_CHARS_IN_ATTRIBUTES) || (entityValue != SINGLE_QUOTE)) {
+            const unsigned char flagIndex = static_cast<unsigned char>(entityValue);
+            TIXMLASSERT( flagIndex < ENTITY_RANGE );
+            _entityFlag[flagIndex] = true;
+        }
     }
     _restrictedEntityFlag[static_cast<unsigned char>('&')] = true;
     _restrictedEntityFlag[static_cast<unsigned char>('<')] = true;

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -2240,13 +2240,18 @@ private:
 class TINYXML2_LIB XMLPrinter : public XMLVisitor
 {
 public:
+    enum EscapeAposCharsInAttributes {
+        ESCAPE_APOS_CHARS_IN_ATTRIBUTES,
+        DONT_ESCAPE_APOS_CHARS_IN_ATTRIBUTES
+    };
+
     /** Construct the printer. If the FILE* is specified,
     	this will print to the FILE. Else it will print
     	to memory, and the result is available in CStr().
     	If 'compact' is set to true, then output is created
     	with only required whitespace and newlines.
     */
-    XMLPrinter( FILE* file=0, bool compact = false, int depth = 0 );
+    XMLPrinter( FILE* file=0, bool compact = false, int depth = 0, EscapeAposCharsInAttributes aposInAttributes = ESCAPE_APOS_CHARS_IN_ATTRIBUTES );
     virtual ~XMLPrinter()	{}
 
     /** If streaming, write the BOM and declaration. */

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -2695,6 +2695,41 @@ int main( int argc, const char ** argv )
 		XMLTest("Test attribute encode with a Hex value", value5, "!"); // hex value in unicode value
 	}
 
+	// ---------- XMLPrinter Apos Escaping ------
+	{
+		const char* testText = "text containing a ' character";
+		XMLDocument doc;
+		XMLElement* element = doc.NewElement( "element" );
+		doc.InsertEndChild( element );
+		element->SetAttribute( "attrib", testText );
+		{
+			XMLPrinter defaultPrinter;
+			doc.Print( &defaultPrinter );
+			const char* defaultOutput = defaultPrinter.CStr();
+			const bool foundTextWithUnescapedApos = (strstr(defaultOutput, testText) != nullptr); 
+			XMLTest("Default XMLPrinter should escape ' characters", false, foundTextWithUnescapedApos);
+			{
+				XMLDocument parsingDoc;
+				parsingDoc.Parse(defaultOutput);
+				const XMLAttribute* attrib = parsingDoc.FirstChildElement("element")->FindAttribute("attrib");
+				XMLTest("Default XMLPrinter should output parsable xml", testText, attrib->Value(), true);
+			}
+		}
+		{
+			XMLPrinter customPrinter(0, false, 0, XMLPrinter::DONT_ESCAPE_APOS_CHARS_IN_ATTRIBUTES);
+			doc.Print( &customPrinter );
+			const char* customOutput = customPrinter.CStr();
+			const bool foundTextWithUnescapedApos = (strstr(customOutput, testText) != nullptr); 
+			XMLTest("Custom XMLPrinter should not escape ' characters", true, foundTextWithUnescapedApos);
+			{
+				XMLDocument parsingDoc;
+				parsingDoc.Parse(customOutput);
+				const XMLAttribute* attrib = parsingDoc.FirstChildElement("element")->FindAttribute("attrib");
+				XMLTest("Custom XMLPrinter should output parsable xml", testText, attrib->Value(), true);
+			}
+		}
+	}
+	
     // ----------- Performance tracking --------------
 	{
 #if defined( _MSC_VER )


### PR DESCRIPTION
This is useful for my project, but the feature was already requested in this old feature request: #345 (Avoid greedy apos entity replacement in attributes).

In my use case the single-quote character is both very important and very common in attributes. As a result, the XML became unnecessarily difficult to read because of all the "\&apos;" escaping. This small change allows the XmlPrinter to be customized so that single-quote characters are not escaped in attributes. Since tinyXML uses double-quotes to surround attributes, the resulting document is still parsable. The impact can be seen in [this commit](https://github.com/Malcohol/SeqWires/compare/99a7efce193740e0a965989c7524f33c62420ba4...7cd63b159c4e02bc72e9bee4b2f19de911ca37de#diff-24b59212be6e70014fbe23881c379b181248949c55608d5aecdd57d861966c81).

Please let me know if you are interested in this functionality and whether there is a straightforward path to getting something like this checked in.