### PR TITLE
Header only file and workflow update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-2019, macos-latest, ubuntu-20.04 ]
+        os: [ windows-2019, macos-latest, ubuntu-22.04, ubuntu-24.04 ]
         cmake: [ 3.15, 3.x ]
         include:
           - os: windows-2019
@@ -14,7 +14,9 @@ jobs:
             tree: tree /F
             CXX: cl
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            tree: tree
+          - os: ubuntu-24.04
             tree: tree
 
           - os: macos-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,16 @@ if (tinyxml2_BUILD_TESTING)
     )
 
     set_tests_properties(xmltest PROPERTIES PASS_REGULAR_EXPRESSION ", Fail 0")
+
+    add_executable(xmltest2 xmltest2.cpp)
+
+    add_test(
+        NAME xmltest2
+        COMMAND xmltest2
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+
+    set_tests_properties(xmltest2 PROPERTIES PASS_REGULAR_EXPRESSION ", Fail 0")
 endif ()
 
 ##

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 TinyXML-2
 =========
 
-[![Test](https://github.com/leethomason/tinyxml2/actions/workflows/test.yml/badge.svg)](https://github.com/leethomason/tinyxml2/actions/workflows/test.yml)
+[![Test](https://github.com/KalanaRatnayake/tinyxml2/actions/workflows/test.yml/badge.svg)](https://github.com/KalanaRatnayake/tinyxml2/actions/workflows/test.yml)
 
 TinyXML-2 is a simple, small, efficient, C++ XML parser that can be
 easily integrated into other programs.
@@ -11,6 +11,9 @@ https://github.com/leethomason/tinyxml2
 
 The online HTML version of these docs:
 http://leethomason.github.io/tinyxml2/
+
+The new Header only file is hosted on github:
+https://github.com/KalanaRatnayake/tinyxml2
 
 Examples are in the "related pages" tab of the HTML docs.
 
@@ -267,6 +270,10 @@ And additionally a test file:
 
 Generally speaking, the intent is that you simply include the tinyxml2.cpp and 
 tinyxml2.h files in your project and build with your other source code.
+
+*Update:* Now the single file header "tinyxml2.hpp" can directly be included in 
+your project directly without worrying about the cpp file and additional integration.
+This can be useful when used in robotics projects.
 
 There is also a CMake build included. CMake is the general build for TinyXML-2.
 

--- a/readme.md
+++ b/readme.md
@@ -12,9 +12,6 @@ https://github.com/leethomason/tinyxml2
 The online HTML version of these docs:
 http://leethomason.github.io/tinyxml2/
 
-The new Header only file is hosted on github:
-https://github.com/KalanaRatnayake/tinyxml2
-
 Examples are in the "related pages" tab of the HTML docs.
 
 What it does.

--- a/tinyxml2.hpp
+++ b/tinyxml2.hpp
@@ -1,8 +1,8 @@
 /*
 
-2025 - This is an modified version by Kalana Ratnayake by combining original
-header file and cpp file into a single header only file for easier
-integration into ROS related projects.
+2025 - This is an modified version by Kalana Ratnayake by combining
+original header file and cpp file into a single header only file for 
+easier integration into ROS related projects.
 
 Original code by Lee Thomason (www.grinninglizard.com)
 

--- a/tinyxml2.hpp
+++ b/tinyxml2.hpp
@@ -1,0 +1,5380 @@
+/*
+Original code by Lee Thomason (www.grinninglizard.com)
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any
+damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must
+not claim that you wrote the original software. If you use this
+software in a product, an acknowledgment in the product documentation
+would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and
+must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+distribution.
+*/
+
+/*
+This is an modified version by Kalana Ratnayake by combining original
+header file and cpp file into a single header only file for easier
+integration into ROS related projects
+*/
+
+#ifndef TINYXML2_COMBINDED
+#define TINYXML2_COMBINDED
+
+#if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__)
+#   include <ctype.h>
+#   include <limits.h>
+#   include <stdio.h>
+#   include <stdlib.h>
+#   include <string.h>
+#	if defined(__PS3__)
+#		include <stddef.h>
+#	endif
+#else
+#   include <cctype>
+#   include <climits>
+#   include <cstdio>
+#   include <cstdlib>
+#   include <cstring>
+#endif
+#include <stdint.h>
+
+/*
+	gcc:
+        g++ -Wall -DTINYXML2_DEBUG tinyxml2.cpp xmltest.cpp -o gccxmltest.exe
+
+    Formatting, Artistic Style:
+        AStyle.exe --style=1tbs --indent-switches --break-closing-brackets --indent-preprocessor tinyxml2.cpp tinyxml2.h
+*/
+
+#if defined( _DEBUG ) || defined (__DEBUG__)
+#   ifndef TINYXML2_DEBUG
+#       define TINYXML2_DEBUG
+#   endif
+#endif
+
+#ifdef _MSC_VER
+#   pragma warning(push)
+#   pragma warning(disable: 4251)
+#endif
+
+#ifdef _MSC_VER
+#   ifdef TINYXML2_EXPORT
+#       define TINYXML2_LIB __declspec(dllexport)
+#   elif defined(TINYXML2_IMPORT)
+#       define TINYXML2_LIB __declspec(dllimport)
+#   else
+#       define TINYXML2_LIB
+#   endif
+#elif __GNUC__ >= 4
+#   define TINYXML2_LIB __attribute__((visibility("default")))
+#else
+#   define TINYXML2_LIB
+#endif
+
+
+#if !defined(TIXMLASSERT)
+#if defined(TINYXML2_DEBUG)
+#   if defined(_MSC_VER)
+#       // "(void)0," is for suppressing C4127 warning in "assert(false)", "assert(true)" and the like
+#       define TIXMLASSERT( x )           do { if ( !((void)0,(x))) { __debugbreak(); } } while(false)
+#   elif defined (ANDROID_NDK)
+#       include <android/log.h>
+#       define TIXMLASSERT( x )           do { if ( !(x)) { __android_log_assert( "assert", "grinliz", "ASSERT in '%s' at %d.", __FILE__, __LINE__ ); } } while(false)
+#   else
+#       include <assert.h>
+#       define TIXMLASSERT                assert
+#   endif
+#else
+#   define TIXMLASSERT( x )               do {} while(false)
+#endif
+#endif
+
+/* Versioning, past 1.0.14:
+	http://semver.org/
+*/
+static const int TIXML2_MAJOR_VERSION = 11;
+static const int TIXML2_MINOR_VERSION = 0;
+static const int TIXML2_PATCH_VERSION = 0;
+
+#define TINYXML2_MAJOR_VERSION 11
+#define TINYXML2_MINOR_VERSION 0
+#define TINYXML2_PATCH_VERSION 0
+
+// A fixed element depth limit is problematic. There needs to be a
+// limit to avoid a stack overflow. However, that limit varies per
+// system, and the capacity of the stack. On the other hand, it's a trivial
+// attack that can result from ill, malicious, or even correctly formed XML,
+// so there needs to be a limit in place.
+static const int TINYXML2_MAX_ELEMENT_DEPTH = 500;
+
+#include <new>		// yes, this one new style header, is in the Android SDK.
+#if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__) || defined(__CC_ARM)
+#   include <stddef.h>
+#   include <stdarg.h>
+#else
+#   include <cstddef>
+#   include <cstdarg>
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
+	// Microsoft Visual Studio, version 2005 and higher. Not WinCE.
+	/*int _snprintf_s(
+	   char *buffer,
+	   size_t sizeOfBuffer,
+	   size_t count,
+	   const char *format [,
+		  argument] ...
+	);*/
+	static inline int TIXML_SNPRINTF( char* buffer, size_t size, const char* format, ... )
+	{
+		va_list va;
+		va_start( va, format );
+		const int result = vsnprintf_s( buffer, size, _TRUNCATE, format, va );
+		va_end( va );
+		return result;
+	}
+
+	static inline int TIXML_VSNPRINTF( char* buffer, size_t size, const char* format, va_list va )
+	{
+		const int result = vsnprintf_s( buffer, size, _TRUNCATE, format, va );
+		return result;
+	}
+
+	#define TIXML_VSCPRINTF	_vscprintf
+	#define TIXML_SSCANF	sscanf_s
+#elif defined _MSC_VER
+	// Microsoft Visual Studio 2003 and earlier or WinCE
+	#define TIXML_SNPRINTF	_snprintf
+	#define TIXML_VSNPRINTF _vsnprintf
+	#define TIXML_SSCANF	sscanf
+	#if (_MSC_VER < 1400 ) && (!defined WINCE)
+		// Microsoft Visual Studio 2003 and not WinCE.
+		#define TIXML_VSCPRINTF   _vscprintf // VS2003's C runtime has this, but VC6 C runtime or WinCE SDK doesn't have.
+	#else
+		// Microsoft Visual Studio 2003 and earlier or WinCE.
+		static inline int TIXML_VSCPRINTF( const char* format, va_list va )
+		{
+			int len = 512;
+			for (;;) {
+				len = len*2;
+				char* str = new char[len]();
+				const int required = _vsnprintf(str, len, format, va);
+				delete[] str;
+				if ( required != -1 ) {
+					TIXMLASSERT( required >= 0 );
+					len = required;
+					break;
+				}
+			}
+			TIXMLASSERT( len >= 0 );
+			return len;
+		}
+	#endif
+#else
+	// GCC version 3 and higher
+	//#warning( "Using sn* functions." )
+	#define TIXML_SNPRINTF	snprintf
+	#define TIXML_VSNPRINTF	vsnprintf
+	static inline int TIXML_VSCPRINTF( const char* format, va_list va )
+	{
+		int len = vsnprintf( 0, 0, format, va );
+		TIXMLASSERT( len >= 0 );
+		return len;
+	}
+	#define TIXML_SSCANF   sscanf
+#endif
+
+#if defined(_WIN64)
+	#define TIXML_FSEEK _fseeki64
+	#define TIXML_FTELL _ftelli64
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
+	#define TIXML_FSEEK fseeko
+	#define TIXML_FTELL ftello
+#elif defined(__ANDROID__) && __ANDROID_API__ > 24
+	#define TIXML_FSEEK fseeko64
+	#define TIXML_FTELL ftello64
+#else
+	#define TIXML_FSEEK fseek
+	#define TIXML_FTELL ftell
+#endif
+
+
+static const char LINE_FEED				= static_cast<char>(0x0a);			// all line endings are normalized to LF
+static const char LF = LINE_FEED;
+static const char CARRIAGE_RETURN		= static_cast<char>(0x0d);			// CR gets filtered out
+static const char CR = CARRIAGE_RETURN;
+static const char SINGLE_QUOTE			= '\'';
+static const char DOUBLE_QUOTE			= '\"';
+
+// Bunch of unicode info at:
+//		http://www.unicode.org/faq/utf_bom.html
+//	ef bb bf (Microsoft "lead bytes") - designates UTF-8
+
+static const unsigned char TIXML_UTF_LEAD_0 = 0xefU;
+static const unsigned char TIXML_UTF_LEAD_1 = 0xbbU;
+static const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
+
+
+namespace tinyxml2
+{
+class XMLDocument;
+class XMLElement;
+class XMLAttribute;
+class XMLComment;
+class XMLText;
+class XMLDeclaration;
+class XMLUnknown;
+class XMLPrinter;
+
+/*
+	A class that wraps strings. Normally stores the start and end
+	pointers into the XML file itself, and will apply normalization
+	and entity translation if actually read. Can also store (and memory
+	manage) a traditional char[]
+
+    Isn't clear why TINYXML2_LIB is needed; but seems to fix #719
+*/
+class TINYXML2_LIB StrPair
+{
+public:
+    enum Mode {
+        NEEDS_ENTITY_PROCESSING			= 0x01,
+        NEEDS_NEWLINE_NORMALIZATION		= 0x02,
+        NEEDS_WHITESPACE_COLLAPSING     = 0x04,
+
+        TEXT_ELEMENT		            = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
+        TEXT_ELEMENT_LEAVE_ENTITIES		= NEEDS_NEWLINE_NORMALIZATION,
+        ATTRIBUTE_NAME		            = 0,
+        ATTRIBUTE_VALUE		            = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
+        ATTRIBUTE_VALUE_LEAVE_ENTITIES  = NEEDS_NEWLINE_NORMALIZATION,
+        COMMENT							= NEEDS_NEWLINE_NORMALIZATION
+    };
+
+    StrPair() : _flags( 0 ), _start( 0 ), _end( 0 ) {}
+    ~StrPair();
+
+    void Set( char* start, char* end, int flags ) {
+        TIXMLASSERT( start );
+        TIXMLASSERT( end );
+        Reset();
+        _start  = start;
+        _end    = end;
+        _flags  = flags | NEEDS_FLUSH;
+    }
+
+    const char* GetStr();
+
+    bool Empty() const {
+        return _start == _end;
+    }
+
+    void SetInternedStr( const char* str ) {
+        Reset();
+        _start = const_cast<char*>(str);
+    }
+
+    void SetStr( const char* str, int flags=0 );
+
+    char* ParseText( char* in, const char* endTag, int strFlags, int* curLineNumPtr );
+    char* ParseName( char* in );
+
+    void TransferTo( StrPair* other );
+	void Reset();
+
+private:
+    void CollapseWhitespace();
+
+    enum {
+        NEEDS_FLUSH = 0x100,
+        NEEDS_DELETE = 0x200
+    };
+
+    int     _flags;
+    char*   _start;
+    char*   _end;
+
+    StrPair( const StrPair& other );	// not supported
+    void operator=( const StrPair& other );	// not supported, use TransferTo()
+};
+
+
+/*
+	A dynamic array of Plain Old Data. Doesn't support constructors, etc.
+	Has a small initial memory pool, so that low or no usage will not
+	cause a call to new/delete
+*/
+template <class T, size_t INITIAL_SIZE>
+class DynArray
+{
+public:
+    DynArray() :
+        _mem( _pool ),
+        _allocated( INITIAL_SIZE ),
+        _size( 0 )
+    {
+    }
+
+    ~DynArray() {
+        if ( _mem != _pool ) {
+            delete [] _mem;
+        }
+    }
+
+    void Clear() {
+        _size = 0;
+    }
+
+    void Push( T t ) {
+        TIXMLASSERT( _size < INT_MAX );
+        EnsureCapacity( _size+1 );
+        _mem[_size] = t;
+        ++_size;
+    }
+
+    T* PushArr( size_t count ) {
+        TIXMLASSERT( _size <= SIZE_MAX - count );
+        EnsureCapacity( _size+count );
+        T* ret = &_mem[_size];
+        _size += count;
+        return ret;
+    }
+
+    T Pop() {
+        TIXMLASSERT( _size > 0 );
+        --_size;
+        return _mem[_size];
+    }
+
+    void PopArr( size_t count ) {
+        TIXMLASSERT( _size >= count );
+        _size -= count;
+    }
+
+    bool Empty() const					{
+        return _size == 0;
+    }
+
+    T& operator[](size_t i) {
+        TIXMLASSERT( i < _size );
+        return _mem[i];
+    }
+
+    const T& operator[](size_t i) const {
+        TIXMLASSERT( i < _size );
+        return _mem[i];
+    }
+
+    const T& PeekTop() const            {
+        TIXMLASSERT( _size > 0 );
+        return _mem[ _size - 1];
+    }
+
+    size_t Size() const {
+        TIXMLASSERT( _size >= 0 );
+        return _size;
+    }
+
+    size_t Capacity() const {
+        TIXMLASSERT( _allocated >= INITIAL_SIZE );
+        return _allocated;
+    }
+
+	void SwapRemove(size_t i) {
+		TIXMLASSERT(i < _size);
+		TIXMLASSERT(_size > 0);
+		_mem[i] = _mem[_size - 1];
+		--_size;
+	}
+
+    const T* Mem() const				{
+        TIXMLASSERT( _mem );
+        return _mem;
+    }
+
+    T* Mem() {
+        TIXMLASSERT( _mem );
+        return _mem;
+    }
+
+private:
+    DynArray( const DynArray& ); // not supported
+    void operator=( const DynArray& ); // not supported
+
+    void EnsureCapacity( size_t cap ) {
+        TIXMLASSERT( cap > 0 );
+        if ( cap > _allocated ) {
+            TIXMLASSERT( cap <= SIZE_MAX / 2 / sizeof(T));
+            const size_t newAllocated = cap * 2;
+            T* newMem = new T[newAllocated];
+            TIXMLASSERT( newAllocated >= _size );
+            memcpy( newMem, _mem, sizeof(T) * _size );	// warning: not using constructors, only works for PODs
+            if ( _mem != _pool ) {
+                delete [] _mem;
+            }
+            _mem = newMem;
+            _allocated = newAllocated;
+        }
+    }
+
+    T*  _mem;
+    T   _pool[INITIAL_SIZE];
+    size_t _allocated;		// objects allocated
+    size_t _size;			// number objects in use
+};
+
+
+/*
+	Parent virtual class of a pool for fast allocation
+	and deallocation of objects.
+*/
+class MemPool
+{
+public:
+    MemPool() {}
+    virtual ~MemPool() {}
+
+    virtual size_t ItemSize() const = 0;
+    virtual void* Alloc() = 0;
+    virtual void Free( void* ) = 0;
+    virtual void SetTracked() = 0;
+};
+
+
+/*
+	Template child class to create pools of the correct type.
+*/
+template< size_t ITEM_SIZE >
+class MemPoolT : public MemPool
+{
+public:
+    MemPoolT() : _blockPtrs(), _root(0), _currentAllocs(0), _nAllocs(0), _maxAllocs(0), _nUntracked(0)	{}
+    ~MemPoolT() {
+        MemPoolT< ITEM_SIZE >::Clear();
+    }
+
+    void Clear() {
+        // Delete the blocks.
+        while( !_blockPtrs.Empty()) {
+            Block* lastBlock = _blockPtrs.Pop();
+            delete lastBlock;
+        }
+        _root = 0;
+        _currentAllocs = 0;
+        _nAllocs = 0;
+        _maxAllocs = 0;
+        _nUntracked = 0;
+    }
+
+    virtual size_t ItemSize() const override {
+        return ITEM_SIZE;
+    }
+    size_t CurrentAllocs() const {
+        return _currentAllocs;
+    }
+
+    virtual void* Alloc() override{
+        if ( !_root ) {
+            // Need a new block.
+            Block* block = new Block;
+            _blockPtrs.Push( block );
+
+            Item* blockItems = block->items;
+            for( size_t i = 0; i < ITEMS_PER_BLOCK - 1; ++i ) {
+                blockItems[i].next = &(blockItems[i + 1]);
+            }
+            blockItems[ITEMS_PER_BLOCK - 1].next = 0;
+            _root = blockItems;
+        }
+        Item* const result = _root;
+        TIXMLASSERT( result != 0 );
+        _root = _root->next;
+
+        ++_currentAllocs;
+        if ( _currentAllocs > _maxAllocs ) {
+            _maxAllocs = _currentAllocs;
+        }
+        ++_nAllocs;
+        ++_nUntracked;
+        return result;
+    }
+
+    virtual void Free( void* mem ) override {
+        if ( !mem ) {
+            return;
+        }
+        --_currentAllocs;
+        Item* item = static_cast<Item*>( mem );
+#ifdef TINYXML2_DEBUG
+        memset( item, 0xfe, sizeof( *item ) );
+#endif
+        item->next = _root;
+        _root = item;
+    }
+    void Trace( const char* name ) {
+        printf( "Mempool %s watermark=%d [%dk] current=%d size=%d nAlloc=%d blocks=%d\n",
+                name, _maxAllocs, _maxAllocs * ITEM_SIZE / 1024, _currentAllocs,
+                ITEM_SIZE, _nAllocs, _blockPtrs.Size() );
+    }
+
+    void SetTracked() override {
+        --_nUntracked;
+    }
+
+    size_t Untracked() const {
+        return _nUntracked;
+    }
+
+	// This number is perf sensitive. 4k seems like a good tradeoff on my machine.
+	// The test file is large, 170k.
+	// Release:		VS2010 gcc(no opt)
+	//		1k:		4000
+	//		2k:		4000
+	//		4k:		3900	21000
+	//		16k:	5200
+	//		32k:	4300
+	//		64k:	4000	21000
+    // Declared public because some compilers do not accept to use ITEMS_PER_BLOCK
+    // in private part if ITEMS_PER_BLOCK is private
+    enum { ITEMS_PER_BLOCK = (4 * 1024) / ITEM_SIZE };
+
+private:
+    MemPoolT( const MemPoolT& ); // not supported
+    void operator=( const MemPoolT& ); // not supported
+
+    union Item {
+        Item*   next;
+        char    itemData[static_cast<size_t>(ITEM_SIZE)];
+    };
+    struct Block {
+        Item items[ITEMS_PER_BLOCK];
+    };
+    DynArray< Block*, 10 > _blockPtrs;
+    Item* _root;
+
+    size_t _currentAllocs;
+    size_t _nAllocs;
+    size_t _maxAllocs;
+    size_t _nUntracked;
+};
+
+
+
+/**
+	Implements the interface to the "Visitor pattern" (see the Accept() method.)
+	If you call the Accept() method, it requires being passed a XMLVisitor
+	class to handle callbacks. For nodes that contain other nodes (Document, Element)
+	you will get called with a VisitEnter/VisitExit pair. Nodes that are always leafs
+	are simply called with Visit().
+
+	If you return 'true' from a Visit method, recursive parsing will continue. If you return
+	false, <b>no children of this node or its siblings</b> will be visited.
+
+	All flavors of Visit methods have a default implementation that returns 'true' (continue
+	visiting). You need to only override methods that are interesting to you.
+
+	Generally Accept() is called on the XMLDocument, although all nodes support visiting.
+
+	You should never change the document from a callback.
+
+	@sa XMLNode::Accept()
+*/
+class TINYXML2_LIB XMLVisitor
+{
+public:
+    virtual ~XMLVisitor() {}
+
+    /// Visit a document.
+    virtual bool VisitEnter( const XMLDocument& /*doc*/ )			{
+        return true;
+    }
+    /// Visit a document.
+    virtual bool VisitExit( const XMLDocument& /*doc*/ )			{
+        return true;
+    }
+
+    /// Visit an element.
+    virtual bool VisitEnter( const XMLElement& /*element*/, const XMLAttribute* /*firstAttribute*/ )	{
+        return true;
+    }
+    /// Visit an element.
+    virtual bool VisitExit( const XMLElement& /*element*/ )			{
+        return true;
+    }
+
+    /// Visit a declaration.
+    virtual bool Visit( const XMLDeclaration& /*declaration*/ )		{
+        return true;
+    }
+    /// Visit a text node.
+    virtual bool Visit( const XMLText& /*text*/ )					{
+        return true;
+    }
+    /// Visit a comment node.
+    virtual bool Visit( const XMLComment& /*comment*/ )				{
+        return true;
+    }
+    /// Visit an unknown node.
+    virtual bool Visit( const XMLUnknown& /*unknown*/ )				{
+        return true;
+    }
+};
+
+// WARNING: must match XMLDocument::_errorNames[]
+enum XMLError {
+    XML_SUCCESS = 0,
+    XML_NO_ATTRIBUTE,
+    XML_WRONG_ATTRIBUTE_TYPE,
+    XML_ERROR_FILE_NOT_FOUND,
+    XML_ERROR_FILE_COULD_NOT_BE_OPENED,
+    XML_ERROR_FILE_READ_ERROR,
+    XML_ERROR_PARSING_ELEMENT,
+    XML_ERROR_PARSING_ATTRIBUTE,
+    XML_ERROR_PARSING_TEXT,
+    XML_ERROR_PARSING_CDATA,
+    XML_ERROR_PARSING_COMMENT,
+    XML_ERROR_PARSING_DECLARATION,
+    XML_ERROR_PARSING_UNKNOWN,
+    XML_ERROR_EMPTY_DOCUMENT,
+    XML_ERROR_MISMATCHED_ELEMENT,
+    XML_ERROR_PARSING,
+    XML_CAN_NOT_CONVERT_TEXT,
+    XML_NO_TEXT_NODE,
+	XML_ELEMENT_DEPTH_EXCEEDED,
+
+	XML_ERROR_COUNT
+};
+
+
+/*
+	Utility functionality.
+*/
+class TINYXML2_LIB XMLUtil
+{
+public:
+    static const char* SkipWhiteSpace( const char* p, int* curLineNumPtr )	{
+        TIXMLASSERT( p );
+
+        while( IsWhiteSpace(*p) ) {
+            if (curLineNumPtr && *p == '\n') {
+                ++(*curLineNumPtr);
+            }
+            ++p;
+        }
+        TIXMLASSERT( p );
+        return p;
+    }
+    static char* SkipWhiteSpace( char* const p, int* curLineNumPtr ) {
+        return const_cast<char*>( SkipWhiteSpace( const_cast<const char*>(p), curLineNumPtr ) );
+    }
+
+    // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
+    // correct, but simple, and usually works.
+    static bool IsWhiteSpace( char p )					{
+        return !IsUTF8Continuation(p) && isspace( static_cast<unsigned char>(p) );
+    }
+
+    inline static bool IsNameStartChar( unsigned char ch ) {
+        if ( ch >= 128 ) {
+            // This is a heuristic guess in attempt to not implement Unicode-aware isalpha()
+            return true;
+        }
+        if ( isalpha( ch ) ) {
+            return true;
+        }
+        return ch == ':' || ch == '_';
+    }
+
+    inline static bool IsNameChar( unsigned char ch ) {
+        return IsNameStartChar( ch )
+               || isdigit( ch )
+               || ch == '.'
+               || ch == '-';
+    }
+
+    inline static bool IsPrefixHex( const char* p) {
+        p = SkipWhiteSpace(p, 0);
+        return p && *p == '0' && ( *(p + 1) == 'x' || *(p + 1) == 'X');
+    }
+
+    inline static bool StringEqual( const char* p, const char* q, int nChar=INT_MAX )  {
+        if ( p == q ) {
+            return true;
+        }
+        TIXMLASSERT( p );
+        TIXMLASSERT( q );
+        TIXMLASSERT( nChar >= 0 );
+        return strncmp( p, q, static_cast<size_t>(nChar) ) == 0;
+    }
+
+    inline static bool IsUTF8Continuation( const char p ) {
+        return ( p & 0x80 ) != 0;
+    }
+
+    static const char* ReadBOM( const char* p, bool* hasBOM );
+    // p is the starting location,
+    // the UTF-8 value of the entity will be placed in value, and length filled in.
+    static const char* GetCharacterRef( const char* p, char* value, int* length );
+    static void ConvertUTF32ToUTF8( unsigned long input, char* output, int* length );
+
+    // converts primitive types to strings
+    static void ToStr( int v, char* buffer, int bufferSize );
+    static void ToStr( unsigned v, char* buffer, int bufferSize );
+    static void ToStr( bool v, char* buffer, int bufferSize );
+    static void ToStr( float v, char* buffer, int bufferSize );
+    static void ToStr( double v, char* buffer, int bufferSize );
+	static void ToStr(int64_t v, char* buffer, int bufferSize);
+    static void ToStr(uint64_t v, char* buffer, int bufferSize);
+
+    // converts strings to primitive types
+    static bool	ToInt( const char* str, int* value );
+    static bool ToUnsigned( const char* str, unsigned* value );
+    static bool	ToBool( const char* str, bool* value );
+    static bool	ToFloat( const char* str, float* value );
+    static bool ToDouble( const char* str, double* value );
+	static bool ToInt64(const char* str, int64_t* value);
+    static bool ToUnsigned64(const char* str, uint64_t* value);
+	// Changes what is serialized for a boolean value.
+	// Default to "true" and "false". Shouldn't be changed
+	// unless you have a special testing or compatibility need.
+	// Be careful: static, global, & not thread safe.
+	// Be sure to set static const memory as parameters.
+	static void SetBoolSerialization(const char* writeTrue, const char* writeFalse);
+
+private:
+	static const char* writeBoolTrue;
+	static const char* writeBoolFalse;
+};
+
+
+/** XMLNode is a base class for every object that is in the
+	XML Document Object Model (DOM), except XMLAttributes.
+	Nodes have siblings, a parent, and children which can
+	be navigated. A node is always in a XMLDocument.
+	The type of a XMLNode can be queried, and it can
+	be cast to its more defined type.
+
+	A XMLDocument allocates memory for all its Nodes.
+	When the XMLDocument gets deleted, all its Nodes
+	will also be deleted.
+
+	@verbatim
+	A Document can contain:	Element	(container or leaf)
+							Comment (leaf)
+							Unknown (leaf)
+							Declaration( leaf )
+
+	An Element can contain:	Element (container or leaf)
+							Text	(leaf)
+							Attributes (not on tree)
+							Comment (leaf)
+							Unknown (leaf)
+
+	@endverbatim
+*/
+class TINYXML2_LIB XMLNode
+{
+    friend class XMLDocument;
+    friend class XMLElement;
+public:
+
+    /// Get the XMLDocument that owns this XMLNode.
+    const XMLDocument* GetDocument() const	{
+        TIXMLASSERT( _document );
+        return _document;
+    }
+    /// Get the XMLDocument that owns this XMLNode.
+    XMLDocument* GetDocument()				{
+        TIXMLASSERT( _document );
+        return _document;
+    }
+
+    /// Safely cast to an Element, or null.
+    virtual XMLElement*		ToElement()		{
+        return 0;
+    }
+    /// Safely cast to Text, or null.
+    virtual XMLText*		ToText()		{
+        return 0;
+    }
+    /// Safely cast to a Comment, or null.
+    virtual XMLComment*		ToComment()		{
+        return 0;
+    }
+    /// Safely cast to a Document, or null.
+    virtual XMLDocument*	ToDocument()	{
+        return 0;
+    }
+    /// Safely cast to a Declaration, or null.
+    virtual XMLDeclaration*	ToDeclaration()	{
+        return 0;
+    }
+    /// Safely cast to an Unknown, or null.
+    virtual XMLUnknown*		ToUnknown()		{
+        return 0;
+    }
+
+    virtual const XMLElement*		ToElement() const		{
+        return 0;
+    }
+    virtual const XMLText*			ToText() const			{
+        return 0;
+    }
+    virtual const XMLComment*		ToComment() const		{
+        return 0;
+    }
+    virtual const XMLDocument*		ToDocument() const		{
+        return 0;
+    }
+    virtual const XMLDeclaration*	ToDeclaration() const	{
+        return 0;
+    }
+    virtual const XMLUnknown*		ToUnknown() const		{
+        return 0;
+    }
+
+    // ChildElementCount was originally suggested by msteiger on the sourceforge page for TinyXML and modified by KB1SPH for TinyXML-2.
+
+    int ChildElementCount(const char *value) const;
+
+    int ChildElementCount() const;
+
+    /** The meaning of 'value' changes for the specific type.
+    	@verbatim
+    	Document:	empty (NULL is returned, not an empty string)
+    	Element:	name of the element
+    	Comment:	the comment text
+    	Unknown:	the tag contents
+    	Text:		the text string
+    	@endverbatim
+    */
+    const char* Value() const;
+
+    /** Set the Value of an XML node.
+    	@sa Value()
+    */
+    void SetValue( const char* val, bool staticMem=false );
+
+    /// Gets the line number the node is in, if the document was parsed from a file.
+    int GetLineNum() const { return _parseLineNum; }
+
+    /// Get the parent of this node on the DOM.
+    const XMLNode*	Parent() const			{
+        return _parent;
+    }
+
+    XMLNode* Parent()						{
+        return _parent;
+    }
+
+    /// Returns true if this node has no children.
+    bool NoChildren() const					{
+        return !_firstChild;
+    }
+
+    /// Get the first child node, or null if none exists.
+    const XMLNode*  FirstChild() const		{
+        return _firstChild;
+    }
+
+    XMLNode*		FirstChild()			{
+        return _firstChild;
+    }
+
+    /** Get the first child element, or optionally the first child
+        element with the specified name.
+    */
+    const XMLElement* FirstChildElement( const char* name = 0 ) const;
+
+    XMLElement* FirstChildElement( const char* name = 0 )	{
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->FirstChildElement( name ));
+    }
+
+    /// Get the last child node, or null if none exists.
+    const XMLNode*	LastChild() const						{
+        return _lastChild;
+    }
+
+    XMLNode*		LastChild()								{
+        return _lastChild;
+    }
+
+    /** Get the last child element or optionally the last child
+        element with the specified name.
+    */
+    const XMLElement* LastChildElement( const char* name = 0 ) const;
+
+    XMLElement* LastChildElement( const char* name = 0 )	{
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->LastChildElement(name) );
+    }
+
+    /// Get the previous (left) sibling node of this node.
+    const XMLNode*	PreviousSibling() const					{
+        return _prev;
+    }
+
+    XMLNode*	PreviousSibling()							{
+        return _prev;
+    }
+
+    /// Get the previous (left) sibling element of this node, with an optionally supplied name.
+    const XMLElement*	PreviousSiblingElement( const char* name = 0 ) const ;
+
+    XMLElement*	PreviousSiblingElement( const char* name = 0 ) {
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->PreviousSiblingElement( name ) );
+    }
+
+    /// Get the next (right) sibling node of this node.
+    const XMLNode*	NextSibling() const						{
+        return _next;
+    }
+
+    XMLNode*	NextSibling()								{
+        return _next;
+    }
+
+    /// Get the next (right) sibling element of this node, with an optionally supplied name.
+    const XMLElement*	NextSiblingElement( const char* name = 0 ) const;
+
+    XMLElement*	NextSiblingElement( const char* name = 0 )	{
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->NextSiblingElement( name ) );
+    }
+
+    /**
+    	Add a child node as the last (right) child.
+		If the child node is already part of the document,
+		it is moved from its old location to the new location.
+		Returns the addThis argument or 0 if the node does not
+		belong to the same document.
+    */
+    XMLNode* InsertEndChild( XMLNode* addThis );
+
+    XMLNode* LinkEndChild( XMLNode* addThis )	{
+        return InsertEndChild( addThis );
+    }
+    /**
+    	Add a child node as the first (left) child.
+		If the child node is already part of the document,
+		it is moved from its old location to the new location.
+		Returns the addThis argument or 0 if the node does not
+		belong to the same document.
+    */
+    XMLNode* InsertFirstChild( XMLNode* addThis );
+    /**
+    	Add a node after the specified child node.
+		If the child node is already part of the document,
+		it is moved from its old location to the new location.
+		Returns the addThis argument or 0 if the afterThis node
+		is not a child of this node, or if the node does not
+		belong to the same document.
+    */
+    XMLNode* InsertAfterChild( XMLNode* afterThis, XMLNode* addThis );
+
+    /**
+    	Delete all the children of this node.
+    */
+    void DeleteChildren();
+
+    /**
+    	Delete a child of this node.
+    */
+    void DeleteChild( XMLNode* node );
+
+    /**
+    	Make a copy of this node, but not its children.
+    	You may pass in a Document pointer that will be
+    	the owner of the new Node. If the 'document' is
+    	null, then the node returned will be allocated
+    	from the current Document. (this->GetDocument())
+
+    	Note: if called on a XMLDocument, this will return null.
+    */
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const = 0;
+
+	/**
+		Make a copy of this node and all its children.
+
+		If the 'target' is null, then the nodes will
+		be allocated in the current document. If 'target'
+        is specified, the memory will be allocated in the
+        specified XMLDocument.
+
+		NOTE: This is probably not the correct tool to
+		copy a document, since XMLDocuments can have multiple
+		top level XMLNodes. You probably want to use
+        XMLDocument::DeepCopy()
+	*/
+	XMLNode* DeepClone( XMLDocument* target ) const;
+
+    /**
+    	Test if 2 nodes are the same, but don't test children.
+    	The 2 nodes do not need to be in the same Document.
+
+    	Note: if called on a XMLDocument, this will return false.
+    */
+    virtual bool ShallowEqual( const XMLNode* compare ) const = 0;
+
+    /** Accept a hierarchical visit of the nodes in the TinyXML-2 DOM. Every node in the
+    	XML tree will be conditionally visited and the host will be called back
+    	via the XMLVisitor interface.
+
+    	This is essentially a SAX interface for TinyXML-2. (Note however it doesn't re-parse
+    	the XML for the callbacks, so the performance of TinyXML-2 is unchanged by using this
+    	interface versus any other.)
+
+    	The interface has been based on ideas from:
+
+    	- http://www.saxproject.org/
+    	- http://c2.com/cgi/wiki?HierarchicalVisitorPattern
+
+    	Which are both good references for "visiting".
+
+    	An example of using Accept():
+    	@verbatim
+    	XMLPrinter printer;
+    	tinyxmlDoc.Accept( &printer );
+    	const char* xmlcstr = printer.CStr();
+    	@endverbatim
+    */
+    virtual bool Accept( XMLVisitor* visitor ) const = 0;
+
+	/**
+		Set user data into the XMLNode. TinyXML-2 in
+		no way processes or interprets user data.
+		It is initially 0.
+	*/
+	void SetUserData(void* userData)	{ _userData = userData; }
+
+	/**
+		Get user data set into the XMLNode. TinyXML-2 in
+		no way processes or interprets user data.
+		It is initially 0.
+	*/
+	void* GetUserData() const			{ return _userData; }
+
+protected:
+    explicit XMLNode( XMLDocument* );
+    virtual ~XMLNode();
+
+    virtual char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr);
+
+    XMLDocument*	_document;
+    XMLNode*		_parent;
+    mutable StrPair	_value;
+    int             _parseLineNum;
+
+    XMLNode*		_firstChild;
+    XMLNode*		_lastChild;
+
+    XMLNode*		_prev;
+    XMLNode*		_next;
+
+	void*			_userData;
+
+private:
+    MemPool*		_memPool;
+    void Unlink( XMLNode* child );
+    static void DeleteNode( XMLNode* node );
+    void InsertChildPreamble( XMLNode* insertThis ) const;
+    const XMLElement* ToElementWithName( const char* name ) const;
+
+    XMLNode( const XMLNode& );	// not supported
+    XMLNode& operator=( const XMLNode& );	// not supported
+};
+
+
+/** XML text.
+
+	Note that a text node can have child element nodes, for example:
+	@verbatim
+	<root>This is <b>bold</b></root>
+	@endverbatim
+
+	A text node can have 2 ways to output the next. "normal" output
+	and CDATA. It will default to the mode it was parsed from the XML file and
+	you generally want to leave it alone, but you can change the output mode with
+	SetCData() and query it with CData().
+*/
+class TINYXML2_LIB XMLText : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual bool Accept( XMLVisitor* visitor ) const override;
+
+    virtual XMLText* ToText() override		{
+        return this;
+    }
+    virtual const XMLText* ToText() const override {
+        return this;
+    }
+
+    /// Declare whether this should be CDATA or standard text.
+    void SetCData( bool isCData )			{
+        _isCData = isCData;
+    }
+    /// Returns true if this is a CDATA text element.
+    bool CData() const						{
+        return _isCData;
+    }
+
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const override;
+    virtual bool ShallowEqual( const XMLNode* compare ) const override;
+
+protected:
+    explicit XMLText( XMLDocument* doc )	: XMLNode( doc ), _isCData( false )	{}
+    virtual ~XMLText()												{}
+
+    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr ) override;
+
+private:
+    bool _isCData;
+
+    XMLText( const XMLText& );	// not supported
+    XMLText& operator=( const XMLText& );	// not supported
+};
+
+
+/** An XML Comment. */
+class TINYXML2_LIB XMLComment : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual XMLComment*	ToComment() override		{
+        return this;
+    }
+    virtual const XMLComment* ToComment() const override {
+        return this;
+    }
+
+    virtual bool Accept( XMLVisitor* visitor ) const override;
+
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const override;
+    virtual bool ShallowEqual( const XMLNode* compare ) const override;
+
+protected:
+    explicit XMLComment( XMLDocument* doc );
+    virtual ~XMLComment();
+
+    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr) override;
+
+private:
+    XMLComment( const XMLComment& );	// not supported
+    XMLComment& operator=( const XMLComment& );	// not supported
+};
+
+
+/** In correct XML the declaration is the first entry in the file.
+	@verbatim
+		<?xml version="1.0" standalone="yes"?>
+	@endverbatim
+
+	TinyXML-2 will happily read or write files without a declaration,
+	however.
+
+	The text of the declaration isn't interpreted. It is parsed
+	and written as a string.
+*/
+class TINYXML2_LIB XMLDeclaration : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual XMLDeclaration*	ToDeclaration() override		{
+        return this;
+    }
+    virtual const XMLDeclaration* ToDeclaration() const override {
+        return this;
+    }
+
+    virtual bool Accept( XMLVisitor* visitor ) const override;
+
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const override;
+    virtual bool ShallowEqual( const XMLNode* compare ) const override;
+
+protected:
+    explicit XMLDeclaration( XMLDocument* doc );
+    virtual ~XMLDeclaration();
+
+    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr ) override;
+
+private:
+    XMLDeclaration( const XMLDeclaration& );	// not supported
+    XMLDeclaration& operator=( const XMLDeclaration& );	// not supported
+};
+
+
+/** Any tag that TinyXML-2 doesn't recognize is saved as an
+	unknown. It is a tag of text, but should not be modified.
+	It will be written back to the XML, unchanged, when the file
+	is saved.
+
+	DTD tags get thrown into XMLUnknowns.
+*/
+class TINYXML2_LIB XMLUnknown : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual XMLUnknown*	ToUnknown() override		{
+        return this;
+    }
+    virtual const XMLUnknown* ToUnknown() const override {
+        return this;
+    }
+
+    virtual bool Accept( XMLVisitor* visitor ) const override;
+
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const override;
+    virtual bool ShallowEqual( const XMLNode* compare ) const override;
+
+protected:
+    explicit XMLUnknown( XMLDocument* doc );
+    virtual ~XMLUnknown();
+
+    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr ) override;
+
+private:
+    XMLUnknown( const XMLUnknown& );	// not supported
+    XMLUnknown& operator=( const XMLUnknown& );	// not supported
+};
+
+
+
+/** An attribute is a name-value pair. Elements have an arbitrary
+	number of attributes, each with a unique name.
+
+	@note The attributes are not XMLNodes. You may only query the
+	Next() attribute in a list.
+*/
+class TINYXML2_LIB XMLAttribute
+{
+    friend class XMLElement;
+public:
+    /// The name of the attribute.
+    const char* Name() const;
+
+    /// The value of the attribute.
+    const char* Value() const;
+
+    /// Gets the line number the attribute is in, if the document was parsed from a file.
+    int GetLineNum() const { return _parseLineNum; }
+
+    /// The next attribute in the list.
+    const XMLAttribute* Next() const {
+        return _next;
+    }
+
+    /** IntValue interprets the attribute as an integer, and returns the value.
+        If the value isn't an integer, 0 will be returned. There is no error checking;
+    	use QueryIntValue() if you need error checking.
+    */
+	int	IntValue() const {
+		int i = 0;
+		QueryIntValue(&i);
+		return i;
+	}
+
+	int64_t Int64Value() const {
+		int64_t i = 0;
+		QueryInt64Value(&i);
+		return i;
+	}
+
+    uint64_t Unsigned64Value() const {
+        uint64_t i = 0;
+        QueryUnsigned64Value(&i);
+        return i;
+    }
+
+    /// Query as an unsigned integer. See IntValue()
+    unsigned UnsignedValue() const			{
+        unsigned i=0;
+        QueryUnsignedValue( &i );
+        return i;
+    }
+    /// Query as a boolean. See IntValue()
+    bool	 BoolValue() const				{
+        bool b=false;
+        QueryBoolValue( &b );
+        return b;
+    }
+    /// Query as a double. See IntValue()
+    double 	 DoubleValue() const			{
+        double d=0;
+        QueryDoubleValue( &d );
+        return d;
+    }
+    /// Query as a float. See IntValue()
+    float	 FloatValue() const				{
+        float f=0;
+        QueryFloatValue( &f );
+        return f;
+    }
+
+    /** QueryIntValue interprets the attribute as an integer, and returns the value
+    	in the provided parameter. The function will return XML_SUCCESS on success,
+    	and XML_WRONG_ATTRIBUTE_TYPE if the conversion is not successful.
+    */
+    XMLError QueryIntValue( int* value ) const;
+    /// See QueryIntValue
+    XMLError QueryUnsignedValue( unsigned int* value ) const;
+	/// See QueryIntValue
+	XMLError QueryInt64Value(int64_t* value) const;
+    /// See QueryIntValue
+    XMLError QueryUnsigned64Value(uint64_t* value) const;
+	/// See QueryIntValue
+    XMLError QueryBoolValue( bool* value ) const;
+    /// See QueryIntValue
+    XMLError QueryDoubleValue( double* value ) const;
+    /// See QueryIntValue
+    XMLError QueryFloatValue( float* value ) const;
+
+    /// Set the attribute to a string value.
+    void SetAttribute( const char* value );
+    /// Set the attribute to value.
+    void SetAttribute( int value );
+    /// Set the attribute to value.
+    void SetAttribute( unsigned value );
+	/// Set the attribute to value.
+	void SetAttribute(int64_t value);
+    /// Set the attribute to value.
+    void SetAttribute(uint64_t value);
+    /// Set the attribute to value.
+    void SetAttribute( bool value );
+    /// Set the attribute to value.
+    void SetAttribute( double value );
+    /// Set the attribute to value.
+    void SetAttribute( float value );
+
+private:
+    enum { BUF_SIZE = 200 };
+
+    XMLAttribute() : _name(), _value(),_parseLineNum( 0 ), _next( 0 ), _memPool( 0 ) {}
+    virtual ~XMLAttribute()	{}
+
+    XMLAttribute( const XMLAttribute& );	// not supported
+    void operator=( const XMLAttribute& );	// not supported
+    void SetName( const char* name );
+
+    char* ParseDeep( char* p, bool processEntities, int* curLineNumPtr );
+
+    mutable StrPair _name;
+    mutable StrPair _value;
+    int             _parseLineNum;
+    XMLAttribute*   _next;
+    MemPool*        _memPool;
+};
+
+
+/** The element is a container class. It has a value, the element name,
+	and can contain other elements, text, comments, and unknowns.
+	Elements also contain an arbitrary number of attributes.
+*/
+class TINYXML2_LIB XMLElement : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    /// Get the name of an element (which is the Value() of the node.)
+    const char* Name() const		{
+        return Value();
+    }
+    /// Set the name of the element.
+    void SetName( const char* str, bool staticMem=false )	{
+        SetValue( str, staticMem );
+    }
+
+    virtual XMLElement* ToElement() override	{
+        return this;
+    }
+    virtual const XMLElement* ToElement() const override {
+        return this;
+    }
+    virtual bool Accept( XMLVisitor* visitor ) const override;
+
+    /** Given an attribute name, Attribute() returns the value
+    	for the attribute of that name, or null if none
+    	exists. For example:
+
+    	@verbatim
+    	const char* value = ele->Attribute( "foo" );
+    	@endverbatim
+
+    	The 'value' parameter is normally null. However, if specified,
+    	the attribute will only be returned if the 'name' and 'value'
+    	match. This allow you to write code:
+
+    	@verbatim
+    	if ( ele->Attribute( "foo", "bar" ) ) callFooIsBar();
+    	@endverbatim
+
+    	rather than:
+    	@verbatim
+    	if ( ele->Attribute( "foo" ) ) {
+    		if ( strcmp( ele->Attribute( "foo" ), "bar" ) == 0 ) callFooIsBar();
+    	}
+    	@endverbatim
+    */
+    const char* Attribute( const char* name, const char* value=0 ) const;
+
+    /** Given an attribute name, IntAttribute() returns the value
+    	of the attribute interpreted as an integer. The default
+        value will be returned if the attribute isn't present,
+        or if there is an error. (For a method with error
+    	checking, see QueryIntAttribute()).
+    */
+	int IntAttribute(const char* name, int defaultValue = 0) const;
+    /// See IntAttribute()
+	unsigned UnsignedAttribute(const char* name, unsigned defaultValue = 0) const;
+	/// See IntAttribute()
+	int64_t Int64Attribute(const char* name, int64_t defaultValue = 0) const;
+    /// See IntAttribute()
+    uint64_t Unsigned64Attribute(const char* name, uint64_t defaultValue = 0) const;
+	/// See IntAttribute()
+	bool BoolAttribute(const char* name, bool defaultValue = false) const;
+    /// See IntAttribute()
+	double DoubleAttribute(const char* name, double defaultValue = 0) const;
+    /// See IntAttribute()
+	float FloatAttribute(const char* name, float defaultValue = 0) const;
+
+    /** Given an attribute name, QueryIntAttribute() returns
+    	XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
+    	can't be performed, or XML_NO_ATTRIBUTE if the attribute
+    	doesn't exist. If successful, the result of the conversion
+    	will be written to 'value'. If not successful, nothing will
+    	be written to 'value'. This allows you to provide default
+    	value:
+
+    	@verbatim
+    	int value = 10;
+    	QueryIntAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
+    	@endverbatim
+    */
+    XMLError QueryIntAttribute( const char* name, int* value ) const				{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryIntValue( value );
+    }
+
+	/// See QueryIntAttribute()
+    XMLError QueryUnsignedAttribute( const char* name, unsigned int* value ) const	{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryUnsignedValue( value );
+    }
+
+	/// See QueryIntAttribute()
+	XMLError QueryInt64Attribute(const char* name, int64_t* value) const {
+		const XMLAttribute* a = FindAttribute(name);
+		if (!a) {
+			return XML_NO_ATTRIBUTE;
+		}
+		return a->QueryInt64Value(value);
+	}
+
+    /// See QueryIntAttribute()
+    XMLError QueryUnsigned64Attribute(const char* name, uint64_t* value) const {
+        const XMLAttribute* a = FindAttribute(name);
+        if(!a) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryUnsigned64Value(value);
+    }
+
+	/// See QueryIntAttribute()
+    XMLError QueryBoolAttribute( const char* name, bool* value ) const				{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryBoolValue( value );
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryDoubleAttribute( const char* name, double* value ) const			{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryDoubleValue( value );
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryFloatAttribute( const char* name, float* value ) const			{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryFloatValue( value );
+    }
+
+	/// See QueryIntAttribute()
+	XMLError QueryStringAttribute(const char* name, const char** value) const {
+		const XMLAttribute* a = FindAttribute(name);
+		if (!a) {
+			return XML_NO_ATTRIBUTE;
+		}
+		*value = a->Value();
+		return XML_SUCCESS;
+	}
+
+
+
+    /** Given an attribute name, QueryAttribute() returns
+    	XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
+    	can't be performed, or XML_NO_ATTRIBUTE if the attribute
+    	doesn't exist. It is overloaded for the primitive types,
+		and is a generally more convenient replacement of
+		QueryIntAttribute() and related functions.
+
+		If successful, the result of the conversion
+    	will be written to 'value'. If not successful, nothing will
+    	be written to 'value'. This allows you to provide default
+    	value:
+
+    	@verbatim
+    	int value = 10;
+    	QueryAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
+    	@endverbatim
+    */
+	XMLError QueryAttribute( const char* name, int* value ) const {
+		return QueryIntAttribute( name, value );
+	}
+
+	XMLError QueryAttribute( const char* name, unsigned int* value ) const {
+		return QueryUnsignedAttribute( name, value );
+	}
+
+	XMLError QueryAttribute(const char* name, int64_t* value) const {
+		return QueryInt64Attribute(name, value);
+	}
+
+    XMLError QueryAttribute(const char* name, uint64_t* value) const {
+        return QueryUnsigned64Attribute(name, value);
+    }
+
+    XMLError QueryAttribute( const char* name, bool* value ) const {
+		return QueryBoolAttribute( name, value );
+	}
+
+	XMLError QueryAttribute( const char* name, double* value ) const {
+		return QueryDoubleAttribute( name, value );
+	}
+
+	XMLError QueryAttribute( const char* name, float* value ) const {
+		return QueryFloatAttribute( name, value );
+	}
+
+	XMLError QueryAttribute(const char* name, const char** value) const {
+		return QueryStringAttribute(name, value);
+	}
+
+	/// Sets the named attribute to value.
+    void SetAttribute( const char* name, const char* value )	{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, int value )			{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, unsigned value )		{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+
+	/// Sets the named attribute to value.
+	void SetAttribute(const char* name, int64_t value) {
+		XMLAttribute* a = FindOrCreateAttribute(name);
+		a->SetAttribute(value);
+	}
+
+    /// Sets the named attribute to value.
+    void SetAttribute(const char* name, uint64_t value) {
+        XMLAttribute* a = FindOrCreateAttribute(name);
+        a->SetAttribute(value);
+    }
+
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, bool value )			{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, double value )		{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, float value )		{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+
+    /**
+    	Delete an attribute.
+    */
+    void DeleteAttribute( const char* name );
+
+    /// Return the first attribute in the list.
+    const XMLAttribute* FirstAttribute() const {
+        return _rootAttribute;
+    }
+    /// Query a specific attribute in the list.
+    const XMLAttribute* FindAttribute( const char* name ) const;
+
+    /** Convenience function for easy access to the text inside an element. Although easy
+    	and concise, GetText() is limited compared to getting the XMLText child
+    	and accessing it directly.
+
+    	If the first child of 'this' is a XMLText, the GetText()
+    	returns the character string of the Text node, else null is returned.
+
+    	This is a convenient method for getting the text of simple contained text:
+    	@verbatim
+    	<foo>This is text</foo>
+    		const char* str = fooElement->GetText();
+    	@endverbatim
+
+    	'str' will be a pointer to "This is text".
+
+    	Note that this function can be misleading. If the element foo was created from
+    	this XML:
+    	@verbatim
+    		<foo><b>This is text</b></foo>
+    	@endverbatim
+
+    	then the value of str would be null. The first child node isn't a text node, it is
+    	another element. From this XML:
+    	@verbatim
+    		<foo>This is <b>text</b></foo>
+    	@endverbatim
+    	GetText() will return "This is ".
+    */
+    const char* GetText() const;
+
+    /** Convenience function for easy access to the text inside an element. Although easy
+    	and concise, SetText() is limited compared to creating an XMLText child
+    	and mutating it directly.
+
+    	If the first child of 'this' is a XMLText, SetText() sets its value to
+		the given string, otherwise it will create a first child that is an XMLText.
+
+    	This is a convenient method for setting the text of simple contained text:
+    	@verbatim
+    	<foo>This is text</foo>
+    		fooElement->SetText( "Hullaballoo!" );
+     	<foo>Hullaballoo!</foo>
+		@endverbatim
+
+    	Note that this function can be misleading. If the element foo was created from
+    	this XML:
+    	@verbatim
+    		<foo><b>This is text</b></foo>
+    	@endverbatim
+
+    	then it will not change "This is text", but rather prefix it with a text element:
+    	@verbatim
+    		<foo>Hullaballoo!<b>This is text</b></foo>
+    	@endverbatim
+
+		For this XML:
+    	@verbatim
+    		<foo />
+    	@endverbatim
+    	SetText() will generate
+    	@verbatim
+    		<foo>Hullaballoo!</foo>
+    	@endverbatim
+    */
+	void SetText( const char* inText );
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText( int value );
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText( unsigned value );
+	/// Convenience method for setting text inside an element. See SetText() for important limitations.
+	void SetText(int64_t value);
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText(uint64_t value);
+	/// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText( bool value );
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText( double value );
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText( float value );
+
+    /**
+    	Convenience method to query the value of a child text node. This is probably best
+    	shown by example. Given you have a document is this form:
+    	@verbatim
+    		<point>
+    			<x>1</x>
+    			<y>1.4</y>
+    		</point>
+    	@endverbatim
+
+    	The QueryIntText() and similar functions provide a safe and easier way to get to the
+    	"value" of x and y.
+
+    	@verbatim
+    		int x = 0;
+    		float y = 0;	// types of x and y are contrived for example
+    		const XMLElement* xElement = pointElement->FirstChildElement( "x" );
+    		const XMLElement* yElement = pointElement->FirstChildElement( "y" );
+    		xElement->QueryIntText( &x );
+    		yElement->QueryFloatText( &y );
+    	@endverbatim
+
+    	@returns XML_SUCCESS (0) on success, XML_CAN_NOT_CONVERT_TEXT if the text cannot be converted
+    			 to the requested type, and XML_NO_TEXT_NODE if there is no child text to query.
+
+    */
+    XMLError QueryIntText( int* ival ) const;
+    /// See QueryIntText()
+    XMLError QueryUnsignedText( unsigned* uval ) const;
+	/// See QueryIntText()
+	XMLError QueryInt64Text(int64_t* uval) const;
+	/// See QueryIntText()
+	XMLError QueryUnsigned64Text(uint64_t* uval) const;
+	/// See QueryIntText()
+    XMLError QueryBoolText( bool* bval ) const;
+    /// See QueryIntText()
+    XMLError QueryDoubleText( double* dval ) const;
+    /// See QueryIntText()
+    XMLError QueryFloatText( float* fval ) const;
+
+	int IntText(int defaultValue = 0) const;
+
+	/// See QueryIntText()
+	unsigned UnsignedText(unsigned defaultValue = 0) const;
+	/// See QueryIntText()
+	int64_t Int64Text(int64_t defaultValue = 0) const;
+    /// See QueryIntText()
+    uint64_t Unsigned64Text(uint64_t defaultValue = 0) const;
+	/// See QueryIntText()
+	bool BoolText(bool defaultValue = false) const;
+	/// See QueryIntText()
+	double DoubleText(double defaultValue = 0) const;
+	/// See QueryIntText()
+    float FloatText(float defaultValue = 0) const;
+
+    /**
+        Convenience method to create a new XMLElement and add it as last (right)
+        child of this node. Returns the created and inserted element.
+    */
+    XMLElement* InsertNewChildElement(const char* name);
+    /// See InsertNewChildElement()
+    XMLComment* InsertNewComment(const char* comment);
+    /// See InsertNewChildElement()
+    XMLText* InsertNewText(const char* text);
+    /// See InsertNewChildElement()
+    XMLDeclaration* InsertNewDeclaration(const char* text);
+    /// See InsertNewChildElement()
+    XMLUnknown* InsertNewUnknown(const char* text);
+
+
+    // internal:
+    enum ElementClosingType {
+        OPEN,		// <foo>
+        CLOSED,		// <foo/>
+        CLOSING		// </foo>
+    };
+    ElementClosingType ClosingType() const {
+        return _closingType;
+    }
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const override;
+    virtual bool ShallowEqual( const XMLNode* compare ) const override;
+
+protected:
+    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr ) override;
+
+private:
+    XMLElement( XMLDocument* doc );
+    virtual ~XMLElement();
+    XMLElement( const XMLElement& );	// not supported
+    void operator=( const XMLElement& );	// not supported
+
+    XMLAttribute* FindOrCreateAttribute( const char* name );
+    char* ParseAttributes( char* p, int* curLineNumPtr );
+    static void DeleteAttribute( XMLAttribute* attribute );
+    XMLAttribute* CreateAttribute();
+
+    enum { BUF_SIZE = 200 };
+    ElementClosingType _closingType;
+    // The attribute list is ordered; there is no 'lastAttribute'
+    // because the list needs to be scanned for dupes before adding
+    // a new attribute.
+    XMLAttribute* _rootAttribute;
+};
+
+
+enum Whitespace {
+    PRESERVE_WHITESPACE,
+    COLLAPSE_WHITESPACE,
+    PEDANTIC_WHITESPACE
+};
+
+
+/** A Document binds together all the functionality.
+	It can be saved, loaded, and printed to the screen.
+	All Nodes are connected and allocated to a Document.
+	If the Document is deleted, all its Nodes are also deleted.
+*/
+class TINYXML2_LIB XMLDocument : public XMLNode
+{
+    friend class XMLElement;
+    // Gives access to SetError and Push/PopDepth, but over-access for everything else.
+    // Wishing C++ had "internal" scope.
+    friend class XMLNode;
+    friend class XMLText;
+    friend class XMLComment;
+    friend class XMLDeclaration;
+    friend class XMLUnknown;
+public:
+    /// constructor
+    XMLDocument( bool processEntities = true, Whitespace whitespaceMode = PRESERVE_WHITESPACE );
+    ~XMLDocument();
+
+    virtual XMLDocument* ToDocument() override		{
+        TIXMLASSERT( this == _document );
+        return this;
+    }
+    virtual const XMLDocument* ToDocument() const override {
+        TIXMLASSERT( this == _document );
+        return this;
+    }
+
+    /**
+    	Parse an XML file from a character string.
+    	Returns XML_SUCCESS (0) on success, or
+    	an errorID.
+
+    	You may optionally pass in the 'nBytes', which is
+    	the number of bytes which will be parsed. If not
+    	specified, TinyXML-2 will assume 'xml' points to a
+    	null terminated string.
+    */
+    XMLError Parse( const char* xml, size_t nBytes=static_cast<size_t>(-1) );
+
+    /**
+    	Load an XML file from disk.
+    	Returns XML_SUCCESS (0) on success, or
+    	an errorID.
+    */
+    XMLError LoadFile( const char* filename );
+
+    /**
+    	Load an XML file from disk. You are responsible
+    	for providing and closing the FILE*.
+
+        NOTE: The file should be opened as binary ("rb")
+        not text in order for TinyXML-2 to correctly
+        do newline normalization.
+
+    	Returns XML_SUCCESS (0) on success, or
+    	an errorID.
+    */
+    XMLError LoadFile( FILE* );
+
+    /**
+    	Save the XML file to disk.
+    	Returns XML_SUCCESS (0) on success, or
+    	an errorID.
+    */
+    XMLError SaveFile( const char* filename, bool compact = false );
+
+    /**
+    	Save the XML file to disk. You are responsible
+    	for providing and closing the FILE*.
+
+    	Returns XML_SUCCESS (0) on success, or
+    	an errorID.
+    */
+    XMLError SaveFile( FILE* fp, bool compact = false );
+
+    bool ProcessEntities() const		{
+        return _processEntities;
+    }
+    Whitespace WhitespaceMode() const	{
+        return _whitespaceMode;
+    }
+
+    /**
+    	Returns true if this document has a leading Byte Order Mark of UTF8.
+    */
+    bool HasBOM() const {
+        return _writeBOM;
+    }
+    /** Sets whether to write the BOM when writing the file.
+    */
+    void SetBOM( bool useBOM ) {
+        _writeBOM = useBOM;
+    }
+
+    /** Return the root element of DOM. Equivalent to FirstChildElement().
+        To get the first node, use FirstChild().
+    */
+    XMLElement* RootElement()				{
+        return FirstChildElement();
+    }
+    const XMLElement* RootElement() const	{
+        return FirstChildElement();
+    }
+
+    /** Print the Document. If the Printer is not provided, it will
+        print to stdout. If you provide Printer, this can print to a file:
+    	@verbatim
+    	XMLPrinter printer( fp );
+    	doc.Print( &printer );
+    	@endverbatim
+
+    	Or you can use a printer to print to memory:
+    	@verbatim
+    	XMLPrinter printer;
+    	doc.Print( &printer );
+    	// printer.CStr() has a const char* to the XML
+    	@endverbatim
+    */
+    void Print( XMLPrinter* streamer=0 ) const;
+    virtual bool Accept( XMLVisitor* visitor ) const override;
+
+    /**
+    	Create a new Element associated with
+    	this Document. The memory for the Element
+    	is managed by the Document.
+    */
+    XMLElement* NewElement( const char* name );
+    /**
+    	Create a new Comment associated with
+    	this Document. The memory for the Comment
+    	is managed by the Document.
+    */
+    XMLComment* NewComment( const char* comment );
+    /**
+    	Create a new Text associated with
+    	this Document. The memory for the Text
+    	is managed by the Document.
+    */
+    XMLText* NewText( const char* text );
+    /**
+    	Create a new Declaration associated with
+    	this Document. The memory for the object
+    	is managed by the Document.
+
+    	If the 'text' param is null, the standard
+    	declaration is used.:
+    	@verbatim
+    		<?xml version="1.0" encoding="UTF-8"?>
+    	@endverbatim
+    */
+    XMLDeclaration* NewDeclaration( const char* text=0 );
+    /**
+    	Create a new Unknown associated with
+    	this Document. The memory for the object
+    	is managed by the Document.
+    */
+    XMLUnknown* NewUnknown( const char* text );
+
+    /**
+    	Delete a node associated with this document.
+    	It will be unlinked from the DOM.
+    */
+    void DeleteNode( XMLNode* node );
+
+    /// Clears the error flags.
+    void ClearError();
+
+    /// Return true if there was an error parsing the document.
+    bool Error() const {
+        return _errorID != XML_SUCCESS;
+    }
+    /// Return the errorID.
+    XMLError  ErrorID() const {
+        return _errorID;
+    }
+	const char* ErrorName() const;
+    static const char* ErrorIDToName(XMLError errorID);
+
+    /** Returns a "long form" error description. A hopefully helpful
+        diagnostic with location, line number, and/or additional info.
+    */
+	const char* ErrorStr() const;
+
+    /// A (trivial) utility function that prints the ErrorStr() to stdout.
+    void PrintError() const;
+
+    /// Return the line where the error occurred, or zero if unknown.
+    int ErrorLineNum() const
+    {
+        return _errorLineNum;
+    }
+
+    /// Clear the document, resetting it to the initial state.
+    void Clear();
+
+	/**
+		Copies this document to a target document.
+		The target will be completely cleared before the copy.
+		If you want to copy a sub-tree, see XMLNode::DeepClone().
+
+		NOTE: that the 'target' must be non-null.
+	*/
+	void DeepCopy(XMLDocument* target) const;
+
+	// internal
+    char* Identify( char* p, XMLNode** node, bool first );
+
+	// internal
+	void MarkInUse(const XMLNode* const);
+
+    virtual XMLNode* ShallowClone( XMLDocument* /*document*/ ) const override{
+        return 0;
+    }
+    virtual bool ShallowEqual( const XMLNode* /*compare*/ ) const override{
+        return false;
+    }
+
+private:
+    XMLDocument( const XMLDocument& );	// not supported
+    void operator=( const XMLDocument& );	// not supported
+
+    bool			_writeBOM;
+    bool			_processEntities;
+    XMLError		_errorID;
+    Whitespace		_whitespaceMode;
+    mutable StrPair	_errorStr;
+    int             _errorLineNum;
+    char*			_charBuffer;
+    int				_parseCurLineNum;
+	int				_parsingDepth;
+	// Memory tracking does add some overhead.
+	// However, the code assumes that you don't
+	// have a bunch of unlinked nodes around.
+	// Therefore it takes less memory to track
+	// in the document vs. a linked list in the XMLNode,
+	// and the performance is the same.
+	DynArray<XMLNode*, 10> _unlinked;
+
+    MemPoolT< sizeof(XMLElement) >	 _elementPool;
+    MemPoolT< sizeof(XMLAttribute) > _attributePool;
+    MemPoolT< sizeof(XMLText) >		 _textPool;
+    MemPoolT< sizeof(XMLComment) >	 _commentPool;
+
+	static const char* _errorNames[XML_ERROR_COUNT];
+
+    void Parse();
+
+    void SetError( XMLError error, int lineNum, const char* format, ... );
+
+	// Something of an obvious security hole, once it was discovered.
+	// Either an ill-formed XML or an excessively deep one can overflow
+	// the stack. Track stack depth, and error out if needed.
+	class DepthTracker {
+	public:
+		explicit DepthTracker(XMLDocument * document) {
+			this->_document = document;
+			document->PushDepth();
+		}
+		~DepthTracker() {
+			_document->PopDepth();
+		}
+	private:
+		XMLDocument * _document;
+	};
+	void PushDepth();
+	void PopDepth();
+
+    template<class NodeType, size_t PoolElementSize>
+    NodeType* CreateUnlinkedNode( MemPoolT<PoolElementSize>& pool );
+};
+
+template<class NodeType, size_t PoolElementSize>
+inline NodeType* XMLDocument::CreateUnlinkedNode( MemPoolT<PoolElementSize>& pool )
+{
+    TIXMLASSERT( sizeof( NodeType ) == PoolElementSize );
+    TIXMLASSERT( sizeof( NodeType ) == pool.ItemSize() );
+    NodeType* returnNode = new (pool.Alloc()) NodeType( this );
+    TIXMLASSERT( returnNode );
+    returnNode->_memPool = &pool;
+
+	_unlinked.Push(returnNode);
+    return returnNode;
+}
+
+/**
+	A XMLHandle is a class that wraps a node pointer with null checks; this is
+	an incredibly useful thing. Note that XMLHandle is not part of the TinyXML-2
+	DOM structure. It is a separate utility class.
+
+	Take an example:
+	@verbatim
+	<Document>
+		<Element attributeA = "valueA">
+			<Child attributeB = "value1" />
+			<Child attributeB = "value2" />
+		</Element>
+	</Document>
+	@endverbatim
+
+	Assuming you want the value of "attributeB" in the 2nd "Child" element, it's very
+	easy to write a *lot* of code that looks like:
+
+	@verbatim
+	XMLElement* root = document.FirstChildElement( "Document" );
+	if ( root )
+	{
+		XMLElement* element = root->FirstChildElement( "Element" );
+		if ( element )
+		{
+			XMLElement* child = element->FirstChildElement( "Child" );
+			if ( child )
+			{
+				XMLElement* child2 = child->NextSiblingElement( "Child" );
+				if ( child2 )
+				{
+					// Finally do something useful.
+	@endverbatim
+
+	And that doesn't even cover "else" cases. XMLHandle addresses the verbosity
+	of such code. A XMLHandle checks for null pointers so it is perfectly safe
+	and correct to use:
+
+	@verbatim
+	XMLHandle docHandle( &document );
+	XMLElement* child2 = docHandle.FirstChildElement( "Document" ).FirstChildElement( "Element" ).FirstChildElement().NextSiblingElement();
+	if ( child2 )
+	{
+		// do something useful
+	@endverbatim
+
+	Which is MUCH more concise and useful.
+
+	It is also safe to copy handles - internally they are nothing more than node pointers.
+	@verbatim
+	XMLHandle handleCopy = handle;
+	@endverbatim
+
+	See also XMLConstHandle, which is the same as XMLHandle, but operates on const objects.
+*/
+class TINYXML2_LIB XMLHandle
+{
+public:
+    /// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
+    explicit XMLHandle( XMLNode* node ) : _node( node ) {
+    }
+    /// Create a handle from a node.
+    explicit XMLHandle( XMLNode& node ) : _node( &node ) {
+    }
+    /// Copy constructor
+    XMLHandle( const XMLHandle& ref ) : _node( ref._node ) {
+    }
+    /// Assignment
+    XMLHandle& operator=( const XMLHandle& ref )							{
+        _node = ref._node;
+        return *this;
+    }
+
+    /// Get the first child of this handle.
+    XMLHandle FirstChild() 													{
+        return XMLHandle( _node ? _node->FirstChild() : 0 );
+    }
+    /// Get the first child element of this handle.
+    XMLHandle FirstChildElement( const char* name = 0 )						{
+        return XMLHandle( _node ? _node->FirstChildElement( name ) : 0 );
+    }
+    /// Get the last child of this handle.
+    XMLHandle LastChild()													{
+        return XMLHandle( _node ? _node->LastChild() : 0 );
+    }
+    /// Get the last child element of this handle.
+    XMLHandle LastChildElement( const char* name = 0 )						{
+        return XMLHandle( _node ? _node->LastChildElement( name ) : 0 );
+    }
+    /// Get the previous sibling of this handle.
+    XMLHandle PreviousSibling()												{
+        return XMLHandle( _node ? _node->PreviousSibling() : 0 );
+    }
+    /// Get the previous sibling element of this handle.
+    XMLHandle PreviousSiblingElement( const char* name = 0 )				{
+        return XMLHandle( _node ? _node->PreviousSiblingElement( name ) : 0 );
+    }
+    /// Get the next sibling of this handle.
+    XMLHandle NextSibling()													{
+        return XMLHandle( _node ? _node->NextSibling() : 0 );
+    }
+    /// Get the next sibling element of this handle.
+    XMLHandle NextSiblingElement( const char* name = 0 )					{
+        return XMLHandle( _node ? _node->NextSiblingElement( name ) : 0 );
+    }
+
+    /// Safe cast to XMLNode. This can return null.
+    XMLNode* ToNode()							{
+        return _node;
+    }
+    /// Safe cast to XMLElement. This can return null.
+    XMLElement* ToElement() 					{
+        return ( _node ? _node->ToElement() : 0 );
+    }
+    /// Safe cast to XMLText. This can return null.
+    XMLText* ToText() 							{
+        return ( _node ? _node->ToText() : 0 );
+    }
+    /// Safe cast to XMLUnknown. This can return null.
+    XMLUnknown* ToUnknown() 					{
+        return ( _node ? _node->ToUnknown() : 0 );
+    }
+    /// Safe cast to XMLDeclaration. This can return null.
+    XMLDeclaration* ToDeclaration() 			{
+        return ( _node ? _node->ToDeclaration() : 0 );
+    }
+
+private:
+    XMLNode* _node;
+};
+
+
+/**
+	A variant of the XMLHandle class for working with const XMLNodes and Documents. It is the
+	same in all regards, except for the 'const' qualifiers. See XMLHandle for API.
+*/
+class TINYXML2_LIB XMLConstHandle
+{
+public:
+    explicit XMLConstHandle( const XMLNode* node ) : _node( node ) {
+    }
+    explicit XMLConstHandle( const XMLNode& node ) : _node( &node ) {
+    }
+    XMLConstHandle( const XMLConstHandle& ref ) : _node( ref._node ) {
+    }
+
+    XMLConstHandle& operator=( const XMLConstHandle& ref )							{
+        _node = ref._node;
+        return *this;
+    }
+
+    const XMLConstHandle FirstChild() const											{
+        return XMLConstHandle( _node ? _node->FirstChild() : 0 );
+    }
+    const XMLConstHandle FirstChildElement( const char* name = 0 ) const				{
+        return XMLConstHandle( _node ? _node->FirstChildElement( name ) : 0 );
+    }
+    const XMLConstHandle LastChild()	const										{
+        return XMLConstHandle( _node ? _node->LastChild() : 0 );
+    }
+    const XMLConstHandle LastChildElement( const char* name = 0 ) const				{
+        return XMLConstHandle( _node ? _node->LastChildElement( name ) : 0 );
+    }
+    const XMLConstHandle PreviousSibling() const									{
+        return XMLConstHandle( _node ? _node->PreviousSibling() : 0 );
+    }
+    const XMLConstHandle PreviousSiblingElement( const char* name = 0 ) const		{
+        return XMLConstHandle( _node ? _node->PreviousSiblingElement( name ) : 0 );
+    }
+    const XMLConstHandle NextSibling() const										{
+        return XMLConstHandle( _node ? _node->NextSibling() : 0 );
+    }
+    const XMLConstHandle NextSiblingElement( const char* name = 0 ) const			{
+        return XMLConstHandle( _node ? _node->NextSiblingElement( name ) : 0 );
+    }
+
+
+    const XMLNode* ToNode() const				{
+        return _node;
+    }
+    const XMLElement* ToElement() const			{
+        return ( _node ? _node->ToElement() : 0 );
+    }
+    const XMLText* ToText() const				{
+        return ( _node ? _node->ToText() : 0 );
+    }
+    const XMLUnknown* ToUnknown() const			{
+        return ( _node ? _node->ToUnknown() : 0 );
+    }
+    const XMLDeclaration* ToDeclaration() const	{
+        return ( _node ? _node->ToDeclaration() : 0 );
+    }
+
+private:
+    const XMLNode* _node;
+};
+
+
+/**
+	Printing functionality. The XMLPrinter gives you more
+	options than the XMLDocument::Print() method.
+
+	It can:
+	-# Print to memory.
+	-# Print to a file you provide.
+	-# Print XML without a XMLDocument.
+
+	Print to Memory
+
+	@verbatim
+	XMLPrinter printer;
+	doc.Print( &printer );
+	SomeFunction( printer.CStr() );
+	@endverbatim
+
+	Print to a File
+
+	You provide the file pointer.
+	@verbatim
+	XMLPrinter printer( fp );
+	doc.Print( &printer );
+	@endverbatim
+
+	Print without a XMLDocument
+
+	When loading, an XML parser is very useful. However, sometimes
+	when saving, it just gets in the way. The code is often set up
+	for streaming, and constructing the DOM is just overhead.
+
+	The Printer supports the streaming case. The following code
+	prints out a trivially simple XML file without ever creating
+	an XML document.
+
+	@verbatim
+	XMLPrinter printer( fp );
+	printer.OpenElement( "foo" );
+	printer.PushAttribute( "foo", "bar" );
+	printer.CloseElement();
+	@endverbatim
+*/
+class TINYXML2_LIB XMLPrinter : public XMLVisitor
+{
+public:
+    /** Construct the printer. If the FILE* is specified,
+    	this will print to the FILE. Else it will print
+    	to memory, and the result is available in CStr().
+    	If 'compact' is set to true, then output is created
+    	with only required whitespace and newlines.
+    */
+    XMLPrinter( FILE* file=0, bool compact = false, int depth = 0 );
+    virtual ~XMLPrinter()	{}
+
+    /** If streaming, write the BOM and declaration. */
+    void PushHeader( bool writeBOM, bool writeDeclaration );
+    /** If streaming, start writing an element.
+        The element must be closed with CloseElement()
+    */
+    void OpenElement( const char* name, bool compactMode=false );
+    /// If streaming, add an attribute to an open element.
+    void PushAttribute( const char* name, const char* value );
+    void PushAttribute( const char* name, int value );
+    void PushAttribute( const char* name, unsigned value );
+	void PushAttribute( const char* name, int64_t value );
+	void PushAttribute( const char* name, uint64_t value );
+	void PushAttribute( const char* name, bool value );
+    void PushAttribute( const char* name, double value );
+    /// If streaming, close the Element.
+    virtual void CloseElement( bool compactMode=false );
+
+    /// Add a text node.
+    void PushText( const char* text, bool cdata=false );
+    /// Add a text node from an integer.
+    void PushText( int value );
+    /// Add a text node from an unsigned.
+    void PushText( unsigned value );
+	/// Add a text node from a signed 64bit integer.
+	void PushText( int64_t value );
+	/// Add a text node from an unsigned 64bit integer.
+	void PushText( uint64_t value );
+	/// Add a text node from a bool.
+    void PushText( bool value );
+    /// Add a text node from a float.
+    void PushText( float value );
+    /// Add a text node from a double.
+    void PushText( double value );
+
+    /// Add a comment
+    void PushComment( const char* comment );
+
+    void PushDeclaration( const char* value );
+    void PushUnknown( const char* value );
+
+    virtual bool VisitEnter( const XMLDocument& /*doc*/ ) override;
+    virtual bool VisitExit( const XMLDocument& /*doc*/ ) override	{
+        return true;
+    }
+
+    virtual bool VisitEnter( const XMLElement& element, const XMLAttribute* attribute ) override;
+    virtual bool VisitExit( const XMLElement& element ) override;
+
+    virtual bool Visit( const XMLText& text ) override;
+    virtual bool Visit( const XMLComment& comment ) override;
+    virtual bool Visit( const XMLDeclaration& declaration ) override;
+    virtual bool Visit( const XMLUnknown& unknown ) override;
+
+    /**
+    	If in print to memory mode, return a pointer to
+    	the XML file in memory.
+    */
+    const char* CStr() const {
+        return _buffer.Mem();
+    }
+    /**
+    	If in print to memory mode, return the size
+    	of the XML file in memory. (Note the size returned
+    	includes the terminating null.)
+    */
+    size_t CStrSize() const {
+        return _buffer.Size();
+    }
+    /**
+    	If in print to memory mode, reset the buffer to the
+    	beginning.
+    */
+    void ClearBuffer( bool resetToFirstElement = true ) {
+        _buffer.Clear();
+        _buffer.Push(0);
+		_firstElement = resetToFirstElement;
+    }
+
+protected:
+	virtual bool CompactMode( const XMLElement& )	{ return _compactMode; }
+
+	/** Prints out the space before an element. You may override to change
+	    the space and tabs used. A PrintSpace() override should call Print().
+	*/
+    virtual void PrintSpace( int depth );
+    virtual void Print( const char* format, ... );
+    virtual void Write( const char* data, size_t size );
+    virtual void Putc( char ch );
+
+    inline void Write(const char* data) { Write(data, strlen(data)); }
+
+    void SealElementIfJustOpened();
+    bool _elementJustOpened;
+    DynArray< const char*, 10 > _stack;
+
+private:
+    /**
+       Prepares to write a new node. This includes sealing an element that was
+       just opened, and writing any whitespace necessary if not in compact mode.
+     */
+    void PrepareForNewNode( bool compactMode );
+    void PrintString( const char*, bool restrictedEntitySet );	// prints out, after detecting entities.
+
+    bool _firstElement;
+    FILE* _fp;
+    int _depth;
+    int _textDepth;
+    bool _processEntities;
+	bool _compactMode;
+
+    enum {
+        ENTITY_RANGE = 64,
+        BUF_SIZE = 200
+    };
+    bool _entityFlag[ENTITY_RANGE];
+    bool _restrictedEntityFlag[ENTITY_RANGE];
+
+    DynArray< char, 20 > _buffer;
+
+    // Prohibit cloning, intentionally not implemented
+    XMLPrinter( const XMLPrinter& );
+    XMLPrinter& operator=( const XMLPrinter& );
+};
+
+
+struct Entity {
+    const char* pattern;
+    int length;
+    char value;
+};
+
+static const int NUM_ENTITIES = 5;
+static const Entity entities[NUM_ENTITIES] = {
+    { "quot", 4,	DOUBLE_QUOTE },
+    { "amp", 3,		'&'  },
+    { "apos", 4,	SINGLE_QUOTE },
+    { "lt",	2, 		'<'	 },
+    { "gt",	2,		'>'	 }
+};
+
+
+StrPair::~StrPair()
+{
+    Reset();
+}
+
+
+void StrPair::TransferTo( StrPair* other )
+{
+    if ( this == other ) {
+        return;
+    }
+    // This in effect implements the assignment operator by "moving"
+    // ownership (as in auto_ptr).
+
+    TIXMLASSERT( other != 0 );
+    TIXMLASSERT( other->_flags == 0 );
+    TIXMLASSERT( other->_start == 0 );
+    TIXMLASSERT( other->_end == 0 );
+
+    other->Reset();
+
+    other->_flags = _flags;
+    other->_start = _start;
+    other->_end = _end;
+
+    _flags = 0;
+    _start = 0;
+    _end = 0;
+}
+
+
+void StrPair::Reset()
+{
+    if ( _flags & NEEDS_DELETE ) {
+        delete [] _start;
+    }
+    _flags = 0;
+    _start = 0;
+    _end = 0;
+}
+
+
+void StrPair::SetStr( const char* str, int flags )
+{
+    TIXMLASSERT( str );
+    Reset();
+    size_t len = strlen( str );
+    TIXMLASSERT( _start == 0 );
+    _start = new char[ len+1 ];
+    memcpy( _start, str, len+1 );
+    _end = _start + len;
+    _flags = flags | NEEDS_DELETE;
+}
+
+
+char* StrPair::ParseText( char* p, const char* endTag, int strFlags, int* curLineNumPtr )
+{
+    TIXMLASSERT( p );
+    TIXMLASSERT( endTag && *endTag );
+	TIXMLASSERT(curLineNumPtr);
+
+    char* start = p;
+    const char  endChar = *endTag;
+    size_t length = strlen( endTag );
+
+    // Inner loop of text parsing.
+    while ( *p ) {
+        if ( *p == endChar && strncmp( p, endTag, length ) == 0 ) {
+            Set( start, p, strFlags );
+            return p + length;
+        } else if (*p == '\n') {
+            ++(*curLineNumPtr);
+        }
+        ++p;
+        TIXMLASSERT( p );
+    }
+    return 0;
+}
+
+
+char* StrPair::ParseName( char* p )
+{
+    if ( !p || !(*p) ) {
+        return 0;
+    }
+    if ( !XMLUtil::IsNameStartChar( static_cast<unsigned char>(*p) ) ) {
+        return 0;
+    }
+
+    char* const start = p;
+    ++p;
+    while ( *p && XMLUtil::IsNameChar( static_cast<unsigned char>(*p) ) ) {
+        ++p;
+    }
+
+    Set( start, p, 0 );
+    return p;
+}
+
+
+void StrPair::CollapseWhitespace()
+{
+    // Adjusting _start would cause undefined behavior on delete[]
+    TIXMLASSERT( ( _flags & NEEDS_DELETE ) == 0 );
+    // Trim leading space.
+    _start = XMLUtil::SkipWhiteSpace( _start, 0 );
+
+    if ( *_start ) {
+        const char* p = _start;	// the read pointer
+        char* q = _start;	// the write pointer
+
+        while( *p ) {
+            if ( XMLUtil::IsWhiteSpace( *p )) {
+                p = XMLUtil::SkipWhiteSpace( p, 0 );
+                if ( *p == 0 ) {
+                    break;    // don't write to q; this trims the trailing space.
+                }
+                *q = ' ';
+                ++q;
+            }
+            *q = *p;
+            ++q;
+            ++p;
+        }
+        *q = 0;
+    }
+}
+
+
+const char* StrPair::GetStr()
+{
+    TIXMLASSERT( _start );
+    TIXMLASSERT( _end );
+    if ( _flags & NEEDS_FLUSH ) {
+        *_end = 0;
+        _flags ^= NEEDS_FLUSH;
+
+        if ( _flags ) {
+            const char* p = _start;	// the read pointer
+            char* q = _start;	// the write pointer
+
+            while( p < _end ) {
+                if ( (_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == CR ) {
+                    // CR-LF pair becomes LF
+                    // CR alone becomes LF
+                    // LF-CR becomes LF
+                    if ( *(p+1) == LF ) {
+                        p += 2;
+                    }
+                    else {
+                        ++p;
+                    }
+                    *q = LF;
+                    ++q;
+                }
+                else if ( (_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == LF ) {
+                    if ( *(p+1) == CR ) {
+                        p += 2;
+                    }
+                    else {
+                        ++p;
+                    }
+                    *q = LF;
+                    ++q;
+                }
+                else if ( (_flags & NEEDS_ENTITY_PROCESSING) && *p == '&' ) {
+                    // Entities handled by tinyXML2:
+                    // - special entities in the entity table [in/out]
+                    // - numeric character reference [in]
+                    //   &#20013; or &#x4e2d;
+
+                    if ( *(p+1) == '#' ) {
+                        const int buflen = 10;
+                        char buf[buflen] = { 0 };
+                        int len = 0;
+                        const char* adjusted = const_cast<char*>( XMLUtil::GetCharacterRef( p, buf, &len ) );
+                        if ( adjusted == 0 ) {
+                            *q = *p;
+                            ++p;
+                            ++q;
+                        }
+                        else {
+                            TIXMLASSERT( 0 <= len && len <= buflen );
+                            TIXMLASSERT( q + len <= adjusted );
+                            p = adjusted;
+                            memcpy( q, buf, len );
+                            q += len;
+                        }
+                    }
+                    else {
+                        bool entityFound = false;
+                        for( int i = 0; i < NUM_ENTITIES; ++i ) {
+                            const Entity& entity = entities[i];
+                            if ( strncmp( p + 1, entity.pattern, entity.length ) == 0
+                                    && *( p + entity.length + 1 ) == ';' ) {
+                                // Found an entity - convert.
+                                *q = entity.value;
+                                ++q;
+                                p += entity.length + 2;
+                                entityFound = true;
+                                break;
+                            }
+                        }
+                        if ( !entityFound ) {
+                            // fixme: treat as error?
+                            ++p;
+                            ++q;
+                        }
+                    }
+                }
+                else {
+                    *q = *p;
+                    ++p;
+                    ++q;
+                }
+            }
+            *q = 0;
+        }
+        // The loop below has plenty going on, and this
+        // is a less useful mode. Break it out.
+        if ( _flags & NEEDS_WHITESPACE_COLLAPSING ) {
+            CollapseWhitespace();
+        }
+        _flags = (_flags & NEEDS_DELETE);
+    }
+    TIXMLASSERT( _start );
+    return _start;
+}
+
+
+
+
+// --------- XMLUtil ----------- //
+
+const char* XMLUtil::writeBoolTrue  = "true";
+const char* XMLUtil::writeBoolFalse = "false";
+
+void XMLUtil::SetBoolSerialization(const char* writeTrue, const char* writeFalse)
+{
+	static const char* defTrue  = "true";
+	static const char* defFalse = "false";
+
+	writeBoolTrue = (writeTrue) ? writeTrue : defTrue;
+	writeBoolFalse = (writeFalse) ? writeFalse : defFalse;
+}
+
+
+const char* XMLUtil::ReadBOM( const char* p, bool* bom )
+{
+    TIXMLASSERT( p );
+    TIXMLASSERT( bom );
+    *bom = false;
+    const unsigned char* pu = reinterpret_cast<const unsigned char*>(p);
+    // Check for BOM:
+    if (    *(pu+0) == TIXML_UTF_LEAD_0
+            && *(pu+1) == TIXML_UTF_LEAD_1
+            && *(pu+2) == TIXML_UTF_LEAD_2 ) {
+        *bom = true;
+        p += 3;
+    }
+    TIXMLASSERT( p );
+    return p;
+}
+
+
+void XMLUtil::ConvertUTF32ToUTF8( unsigned long input, char* output, int* length )
+{
+    const unsigned long BYTE_MASK = 0xBF;
+    const unsigned long BYTE_MARK = 0x80;
+    const unsigned long FIRST_BYTE_MARK[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
+
+    if (input < 0x80) {
+        *length = 1;
+    }
+    else if ( input < 0x800 ) {
+        *length = 2;
+    }
+    else if ( input < 0x10000 ) {
+        *length = 3;
+    }
+    else if ( input < 0x200000 ) {
+        *length = 4;
+    }
+    else {
+        *length = 0;    // This code won't convert this correctly anyway.
+        return;
+    }
+
+    output += *length;
+
+    // Scary scary fall throughs are annotated with carefully designed comments
+    // to suppress compiler warnings such as -Wimplicit-fallthrough in gcc
+    switch (*length) {
+        case 4:
+            --output;
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+            //fall through
+        case 3:
+            --output;
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+            //fall through
+        case 2:
+            --output;
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+            //fall through
+        case 1:
+            --output;
+            *output = static_cast<char>(input | FIRST_BYTE_MARK[*length]);
+            break;
+        default:
+            TIXMLASSERT( false );
+    }
+}
+
+
+const char* XMLUtil::GetCharacterRef(const char* p, char* value, int* length)
+{
+    // Assume an entity, and pull it out.
+    *length = 0;
+
+    static const uint32_t MAX_CODE_POINT = 0x10FFFF;
+
+    if (*(p + 1) == '#' && *(p + 2)) {
+        uint32_t ucs = 0;
+        ptrdiff_t delta = 0;
+        uint32_t mult = 1;
+        static const char SEMICOLON = ';';
+
+        bool hex = false;
+        uint32_t radix = 10;
+        const char* q = 0;
+        char terminator = '#';
+
+        if (*(p + 2) == 'x') {
+            // Hexadecimal.
+            hex = true;
+            radix = 16;
+            terminator = 'x';
+
+            q = p + 3;
+        }
+        else {
+            // Decimal.
+            q = p + 2;
+        }
+        if (!(*q)) {
+            return 0;
+        }
+
+        q = strchr(q, SEMICOLON);
+        if (!q) {
+            return 0;
+        }
+        TIXMLASSERT(*q == SEMICOLON);
+
+        delta = q - p;
+        --q;
+
+        while (*q != terminator) {
+            uint32_t digit = 0;
+
+            if (*q >= '0' && *q <= '9') {
+                digit = *q - '0';
+            }
+            else if (hex && (*q >= 'a' && *q <= 'f')) {
+                digit = *q - 'a' + 10;
+            }
+            else if (hex && (*q >= 'A' && *q <= 'F')) {
+                digit = *q - 'A' + 10;
+            }
+            else {
+                return 0;
+            }
+            TIXMLASSERT(digit < radix);
+
+            const unsigned int digitScaled = mult * digit;
+            ucs += digitScaled;
+            mult *= radix;       
+            
+            // Security check: could a value exist that is out of range?
+            // Easily; limit to the MAX_CODE_POINT, which also allows for a
+            // bunch of leading zeroes.
+            if (mult > MAX_CODE_POINT) {
+                mult = MAX_CODE_POINT;
+            }
+            --q;
+        }
+        // Out of range:
+        if (ucs > MAX_CODE_POINT) {
+            return 0;
+        }
+        // convert the UCS to UTF-8
+        ConvertUTF32ToUTF8(ucs, value, length);
+		if (length == 0) {
+            // If length is 0, there was an error. (Security? Bad input?)
+            // Fail safely.
+			return 0;
+		}
+        return p + delta + 1;
+    }
+    return p + 1;
+}
+
+void XMLUtil::ToStr( int v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%d", v );
+}
+
+
+void XMLUtil::ToStr( unsigned v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%u", v );
+}
+
+
+void XMLUtil::ToStr( bool v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%s", v ? writeBoolTrue : writeBoolFalse);
+}
+
+/*
+	ToStr() of a number is a very tricky topic.
+	https://github.com/leethomason/tinyxml2/issues/106
+*/
+void XMLUtil::ToStr( float v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%.8g", v );
+}
+
+
+void XMLUtil::ToStr( double v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%.17g", v );
+}
+
+
+void XMLUtil::ToStr( int64_t v, char* buffer, int bufferSize )
+{
+	// horrible syntax trick to make the compiler happy about %lld
+	TIXML_SNPRINTF(buffer, bufferSize, "%lld", static_cast<long long>(v));
+}
+
+void XMLUtil::ToStr( uint64_t v, char* buffer, int bufferSize )
+{
+    // horrible syntax trick to make the compiler happy about %llu
+    TIXML_SNPRINTF(buffer, bufferSize, "%llu", static_cast<unsigned long long>(v));
+}
+
+bool XMLUtil::ToInt(const char* str, int* value)
+{
+    if (IsPrefixHex(str)) {
+        unsigned v;
+        if (TIXML_SSCANF(str, "%x", &v) == 1) {
+            *value = static_cast<int>(v);
+            return true;
+        }
+    }
+    else {
+        if (TIXML_SSCANF(str, "%d", value) == 1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool XMLUtil::ToUnsigned(const char* str, unsigned* value)
+{
+    if (TIXML_SSCANF(str, IsPrefixHex(str) ? "%x" : "%u", value) == 1) {
+        return true;
+    }
+    return false;
+}
+
+bool XMLUtil::ToBool( const char* str, bool* value )
+{
+    int ival = 0;
+    if ( ToInt( str, &ival )) {
+        *value = (ival==0) ? false : true;
+        return true;
+    }
+    static const char* TRUE_VALS[] = { "true", "True", "TRUE", 0 };
+    static const char* FALSE_VALS[] = { "false", "False", "FALSE", 0 };
+
+    for (int i = 0; TRUE_VALS[i]; ++i) {
+        if (StringEqual(str, TRUE_VALS[i])) {
+            *value = true;
+            return true;
+        }
+    }
+    for (int i = 0; FALSE_VALS[i]; ++i) {
+        if (StringEqual(str, FALSE_VALS[i])) {
+            *value = false;
+            return true;
+        }
+    }
+    return false;
+}
+
+
+bool XMLUtil::ToFloat( const char* str, float* value )
+{
+    if ( TIXML_SSCANF( str, "%f", value ) == 1 ) {
+        return true;
+    }
+    return false;
+}
+
+
+bool XMLUtil::ToDouble( const char* str, double* value )
+{
+    if ( TIXML_SSCANF( str, "%lf", value ) == 1 ) {
+        return true;
+    }
+    return false;
+}
+
+
+bool XMLUtil::ToInt64(const char* str, int64_t* value)
+{
+    if (IsPrefixHex(str)) {
+        unsigned long long v = 0;	// horrible syntax trick to make the compiler happy about %llx
+        if (TIXML_SSCANF(str, "%llx", &v) == 1) {
+            *value = static_cast<int64_t>(v);
+            return true;
+        }
+    }
+    else {
+        long long v = 0;	// horrible syntax trick to make the compiler happy about %lld
+        if (TIXML_SSCANF(str, "%lld", &v) == 1) {
+            *value = static_cast<int64_t>(v);
+            return true;
+        }
+    }
+	return false;
+}
+
+
+bool XMLUtil::ToUnsigned64(const char* str, uint64_t* value) {
+    unsigned long long v = 0;	// horrible syntax trick to make the compiler happy about %llu
+    if(TIXML_SSCANF(str, IsPrefixHex(str) ? "%llx" : "%llu", &v) == 1) {
+        *value = static_cast<uint64_t>(v);
+        return true;
+    }
+    return false;
+}
+
+
+char* XMLDocument::Identify( char* p, XMLNode** node, bool first )
+{
+    TIXMLASSERT( node );
+    TIXMLASSERT( p );
+    char* const start = p;
+    int const startLine = _parseCurLineNum;
+    p = XMLUtil::SkipWhiteSpace( p, &_parseCurLineNum );
+    if( !*p ) {
+        *node = 0;
+        TIXMLASSERT( p );
+        return p;
+    }
+
+    // These strings define the matching patterns:
+    static const char* xmlHeader		= { "<?" };
+    static const char* commentHeader	= { "<!--" };
+    static const char* cdataHeader		= { "<![CDATA[" };
+    static const char* dtdHeader		= { "<!" };
+    static const char* elementHeader	= { "<" };	// and a header for everything else; check last.
+
+    static const int xmlHeaderLen		= 2;
+    static const int commentHeaderLen	= 4;
+    static const int cdataHeaderLen		= 9;
+    static const int dtdHeaderLen		= 2;
+    static const int elementHeaderLen	= 1;
+
+    TIXMLASSERT( sizeof( XMLComment ) == sizeof( XMLUnknown ) );		// use same memory pool
+    TIXMLASSERT( sizeof( XMLComment ) == sizeof( XMLDeclaration ) );	// use same memory pool
+    XMLNode* returnNode = 0;
+    if ( XMLUtil::StringEqual( p, xmlHeader, xmlHeaderLen ) ) {
+        returnNode = CreateUnlinkedNode<XMLDeclaration>( _commentPool );
+        returnNode->_parseLineNum = _parseCurLineNum;
+        p += xmlHeaderLen;
+    }
+    else if ( XMLUtil::StringEqual( p, commentHeader, commentHeaderLen ) ) {
+        returnNode = CreateUnlinkedNode<XMLComment>( _commentPool );
+        returnNode->_parseLineNum = _parseCurLineNum;
+        p += commentHeaderLen;
+    }
+    else if ( XMLUtil::StringEqual( p, cdataHeader, cdataHeaderLen ) ) {
+        XMLText* text = CreateUnlinkedNode<XMLText>( _textPool );
+        returnNode = text;
+        returnNode->_parseLineNum = _parseCurLineNum;
+        p += cdataHeaderLen;
+        text->SetCData( true );
+    }
+    else if ( XMLUtil::StringEqual( p, dtdHeader, dtdHeaderLen ) ) {
+        returnNode = CreateUnlinkedNode<XMLUnknown>( _commentPool );
+        returnNode->_parseLineNum = _parseCurLineNum;
+        p += dtdHeaderLen;
+    }
+    else if ( XMLUtil::StringEqual( p, elementHeader, elementHeaderLen ) ) {
+
+        // Preserve whitespace pedantically before closing tag, when it's immediately after opening tag
+        if (WhitespaceMode() == PEDANTIC_WHITESPACE && first && p != start && *(p + elementHeaderLen) == '/') {
+            returnNode = CreateUnlinkedNode<XMLText>(_textPool);
+            returnNode->_parseLineNum = startLine;
+            p = start;	// Back it up, all the text counts.
+            _parseCurLineNum = startLine;
+        }
+        else {
+            returnNode = CreateUnlinkedNode<XMLElement>(_elementPool);
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += elementHeaderLen;
+        }
+    }
+    else {
+        returnNode = CreateUnlinkedNode<XMLText>( _textPool );
+        returnNode->_parseLineNum = _parseCurLineNum; // Report line of first non-whitespace character
+        p = start;	// Back it up, all the text counts.
+        _parseCurLineNum = startLine;
+    }
+
+    TIXMLASSERT( returnNode );
+    TIXMLASSERT( p );
+    *node = returnNode;
+    return p;
+}
+
+
+bool XMLDocument::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    if ( visitor->VisitEnter( *this ) ) {
+        for ( const XMLNode* node=FirstChild(); node; node=node->NextSibling() ) {
+            if ( !node->Accept( visitor ) ) {
+                break;
+            }
+        }
+    }
+    return visitor->VisitExit( *this );
+}
+
+
+// --------- XMLNode ----------- //
+
+XMLNode::XMLNode( XMLDocument* doc ) :
+    _document( doc ),
+    _parent( 0 ),
+    _value(),
+    _parseLineNum( 0 ),
+    _firstChild( 0 ), _lastChild( 0 ),
+    _prev( 0 ), _next( 0 ),
+	_userData( 0 ),
+    _memPool( 0 )
+{
+}
+
+
+XMLNode::~XMLNode()
+{
+    DeleteChildren();
+    if ( _parent ) {
+        _parent->Unlink( this );
+    }
+}
+
+// ChildElementCount was originally suggested by msteiger on the sourceforge page for TinyXML and modified by KB1SPH for TinyXML-2.
+
+int XMLNode::ChildElementCount(const char *value) const {
+	int count = 0;
+
+	const XMLElement *e = FirstChildElement(value);
+
+	while (e) {
+		e = e->NextSiblingElement(value);
+		count++;
+	}
+
+	return count;
+}
+
+int XMLNode::ChildElementCount() const {
+	int count = 0;
+
+	const XMLElement *e = FirstChildElement();
+
+	while (e) {
+		e = e->NextSiblingElement();
+		count++;
+	}
+
+	return count;
+}
+
+const char* XMLNode::Value() const
+{
+    // Edge case: XMLDocuments don't have a Value. Return null.
+    if ( this->ToDocument() )
+        return 0;
+    return _value.GetStr();
+}
+
+void XMLNode::SetValue( const char* str, bool staticMem )
+{
+    if ( staticMem ) {
+        _value.SetInternedStr( str );
+    }
+    else {
+        _value.SetStr( str );
+    }
+}
+
+XMLNode* XMLNode::DeepClone(XMLDocument* target) const
+{
+	XMLNode* clone = this->ShallowClone(target);
+	if (!clone) return 0;
+
+	for (const XMLNode* child = this->FirstChild(); child; child = child->NextSibling()) {
+		XMLNode* childClone = child->DeepClone(target);
+		TIXMLASSERT(childClone);
+		clone->InsertEndChild(childClone);
+	}
+	return clone;
+}
+
+void XMLNode::DeleteChildren()
+{
+    while( _firstChild ) {
+        TIXMLASSERT( _lastChild );
+        DeleteChild( _firstChild );
+    }
+    _firstChild = _lastChild = 0;
+}
+
+
+void XMLNode::Unlink( XMLNode* child )
+{
+    TIXMLASSERT( child );
+    TIXMLASSERT( child->_document == _document );
+    TIXMLASSERT( child->_parent == this );
+    if ( child == _firstChild ) {
+        _firstChild = _firstChild->_next;
+    }
+    if ( child == _lastChild ) {
+        _lastChild = _lastChild->_prev;
+    }
+
+    if ( child->_prev ) {
+        child->_prev->_next = child->_next;
+    }
+    if ( child->_next ) {
+        child->_next->_prev = child->_prev;
+    }
+	child->_next = 0;
+	child->_prev = 0;
+	child->_parent = 0;
+}
+
+
+void XMLNode::DeleteChild( XMLNode* node )
+{
+    TIXMLASSERT( node );
+    TIXMLASSERT( node->_document == _document );
+    TIXMLASSERT( node->_parent == this );
+    Unlink( node );
+	TIXMLASSERT(node->_prev == 0);
+	TIXMLASSERT(node->_next == 0);
+	TIXMLASSERT(node->_parent == 0);
+    DeleteNode( node );
+}
+
+
+XMLNode* XMLNode::InsertEndChild( XMLNode* addThis )
+{
+    TIXMLASSERT( addThis );
+    if ( addThis->_document != _document ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+    InsertChildPreamble( addThis );
+
+    if ( _lastChild ) {
+        TIXMLASSERT( _firstChild );
+        TIXMLASSERT( _lastChild->_next == 0 );
+        _lastChild->_next = addThis;
+        addThis->_prev = _lastChild;
+        _lastChild = addThis;
+
+        addThis->_next = 0;
+    }
+    else {
+        TIXMLASSERT( _firstChild == 0 );
+        _firstChild = _lastChild = addThis;
+
+        addThis->_prev = 0;
+        addThis->_next = 0;
+    }
+    addThis->_parent = this;
+    return addThis;
+}
+
+
+XMLNode* XMLNode::InsertFirstChild( XMLNode* addThis )
+{
+    TIXMLASSERT( addThis );
+    if ( addThis->_document != _document ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+    InsertChildPreamble( addThis );
+
+    if ( _firstChild ) {
+        TIXMLASSERT( _lastChild );
+        TIXMLASSERT( _firstChild->_prev == 0 );
+
+        _firstChild->_prev = addThis;
+        addThis->_next = _firstChild;
+        _firstChild = addThis;
+
+        addThis->_prev = 0;
+    }
+    else {
+        TIXMLASSERT( _lastChild == 0 );
+        _firstChild = _lastChild = addThis;
+
+        addThis->_prev = 0;
+        addThis->_next = 0;
+    }
+    addThis->_parent = this;
+    return addThis;
+}
+
+
+XMLNode* XMLNode::InsertAfterChild( XMLNode* afterThis, XMLNode* addThis )
+{
+    TIXMLASSERT( addThis );
+    if ( addThis->_document != _document ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+
+    TIXMLASSERT( afterThis );
+
+    if ( afterThis->_parent != this ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+    if ( afterThis == addThis ) {
+        // Current state: BeforeThis -> AddThis -> OneAfterAddThis
+        // Now AddThis must disappear from it's location and then
+        // reappear between BeforeThis and OneAfterAddThis.
+        // So just leave it where it is.
+        return addThis;
+    }
+
+    if ( afterThis->_next == 0 ) {
+        // The last node or the only node.
+        return InsertEndChild( addThis );
+    }
+    InsertChildPreamble( addThis );
+    addThis->_prev = afterThis;
+    addThis->_next = afterThis->_next;
+    afterThis->_next->_prev = addThis;
+    afterThis->_next = addThis;
+    addThis->_parent = this;
+    return addThis;
+}
+
+
+
+
+const XMLElement* XMLNode::FirstChildElement( const char* name ) const
+{
+    for( const XMLNode* node = _firstChild; node; node = node->_next ) {
+        const XMLElement* element = node->ToElementWithName( name );
+        if ( element ) {
+            return element;
+        }
+    }
+    return 0;
+}
+
+
+const XMLElement* XMLNode::LastChildElement( const char* name ) const
+{
+    for( const XMLNode* node = _lastChild; node; node = node->_prev ) {
+        const XMLElement* element = node->ToElementWithName( name );
+        if ( element ) {
+            return element;
+        }
+    }
+    return 0;
+}
+
+
+const XMLElement* XMLNode::NextSiblingElement( const char* name ) const
+{
+    for( const XMLNode* node = _next; node; node = node->_next ) {
+        const XMLElement* element = node->ToElementWithName( name );
+        if ( element ) {
+            return element;
+        }
+    }
+    return 0;
+}
+
+
+const XMLElement* XMLNode::PreviousSiblingElement( const char* name ) const
+{
+    for( const XMLNode* node = _prev; node; node = node->_prev ) {
+        const XMLElement* element = node->ToElementWithName( name );
+        if ( element ) {
+            return element;
+        }
+    }
+    return 0;
+}
+
+
+char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
+{
+    // This is a recursive method, but thinking about it "at the current level"
+    // it is a pretty simple flat list:
+    //		<foo/>
+    //		<!-- comment -->
+    //
+    // With a special case:
+    //		<foo>
+    //		</foo>
+    //		<!-- comment -->
+    //
+    // Where the closing element (/foo) *must* be the next thing after the opening
+    // element, and the names must match. BUT the tricky bit is that the closing
+    // element will be read by the child.
+    //
+    // 'endTag' is the end tag for this node, it is returned by a call to a child.
+    // 'parentEnd' is the end tag for the parent, which is filled in and returned.
+
+	XMLDocument::DepthTracker tracker(_document);
+	if (_document->Error())
+		return 0;
+
+	bool first = true;
+	while( p && *p ) {
+        XMLNode* node = 0;
+
+        p = _document->Identify( p, &node, first );
+        TIXMLASSERT( p );
+        if ( node == 0 ) {
+            break;
+        }
+        first = false;
+
+       const int initialLineNum = node->_parseLineNum;
+
+        StrPair endTag;
+        p = node->ParseDeep( p, &endTag, curLineNumPtr );
+        if ( !p ) {
+            _document->DeleteNode( node );
+            if ( !_document->Error() ) {
+                _document->SetError( XML_ERROR_PARSING, initialLineNum, 0);
+            }
+            break;
+        }
+
+        const XMLDeclaration* const decl = node->ToDeclaration();
+        if ( decl ) {
+            // Declarations are only allowed at document level
+            //
+            // Multiple declarations are allowed but all declarations
+            // must occur before anything else. 
+            //
+            // Optimized due to a security test case. If the first node is 
+            // a declaration, and the last node is a declaration, then only 
+            // declarations have so far been added.
+            bool wellLocated = false;
+
+            if (ToDocument()) {
+                if (FirstChild()) {
+                    wellLocated =
+                        FirstChild() &&
+                        FirstChild()->ToDeclaration() &&
+                        LastChild() &&
+                        LastChild()->ToDeclaration();
+                }
+                else {
+                    wellLocated = true;
+                }
+            }
+            if ( !wellLocated ) {
+                _document->SetError( XML_ERROR_PARSING_DECLARATION, initialLineNum, "XMLDeclaration value=%s", decl->Value());
+                _document->DeleteNode( node );
+                break;
+            }
+        }
+
+        XMLElement* ele = node->ToElement();
+        if ( ele ) {
+            // We read the end tag. Return it to the parent.
+            if ( ele->ClosingType() == XMLElement::CLOSING ) {
+                if ( parentEndTag ) {
+                    ele->_value.TransferTo( parentEndTag );
+                }
+                node->_memPool->SetTracked();   // created and then immediately deleted.
+                DeleteNode( node );
+                return p;
+            }
+
+            // Handle an end tag returned to this level.
+            // And handle a bunch of annoying errors.
+            bool mismatch = false;
+            if ( endTag.Empty() ) {
+                if ( ele->ClosingType() == XMLElement::OPEN ) {
+                    mismatch = true;
+                }
+            }
+            else {
+                if ( ele->ClosingType() != XMLElement::OPEN ) {
+                    mismatch = true;
+                }
+                else if ( !XMLUtil::StringEqual( endTag.GetStr(), ele->Name() ) ) {
+                    mismatch = true;
+                }
+            }
+            if ( mismatch ) {
+                _document->SetError( XML_ERROR_MISMATCHED_ELEMENT, initialLineNum, "XMLElement name=%s", ele->Name());
+                _document->DeleteNode( node );
+                break;
+            }
+        }
+        InsertEndChild( node );
+    }
+    return 0;
+}
+
+/*static*/ void XMLNode::DeleteNode( XMLNode* node )
+{
+    if ( node == 0 ) {
+        return;
+    }
+	TIXMLASSERT(node->_document);
+	if (!node->ToDocument()) {
+		node->_document->MarkInUse(node);
+	}
+
+    MemPool* pool = node->_memPool;
+    node->~XMLNode();
+    pool->Free( node );
+}
+
+void XMLNode::InsertChildPreamble( XMLNode* insertThis ) const
+{
+    TIXMLASSERT( insertThis );
+    TIXMLASSERT( insertThis->_document == _document );
+
+	if (insertThis->_parent) {
+        insertThis->_parent->Unlink( insertThis );
+	}
+	else {
+		insertThis->_document->MarkInUse(insertThis);
+        insertThis->_memPool->SetTracked();
+	}
+}
+
+const XMLElement* XMLNode::ToElementWithName( const char* name ) const
+{
+    const XMLElement* element = this->ToElement();
+    if ( element == 0 ) {
+        return 0;
+    }
+    if ( name == 0 ) {
+        return element;
+    }
+    if ( XMLUtil::StringEqual( element->Name(), name ) ) {
+       return element;
+    }
+    return 0;
+}
+
+// --------- XMLText ---------- //
+char* XMLText::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
+{
+    if ( this->CData() ) {
+        p = _value.ParseText( p, "]]>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
+        if ( !p ) {
+            _document->SetError( XML_ERROR_PARSING_CDATA, _parseLineNum, 0 );
+        }
+        return p;
+    }
+    else {
+        int flags = _document->ProcessEntities() ? StrPair::TEXT_ELEMENT : StrPair::TEXT_ELEMENT_LEAVE_ENTITIES;
+        if ( _document->WhitespaceMode() == COLLAPSE_WHITESPACE ) {
+            flags |= StrPair::NEEDS_WHITESPACE_COLLAPSING;
+        }
+
+        p = _value.ParseText( p, "<", flags, curLineNumPtr );
+        if ( p && *p ) {
+            return p-1;
+        }
+        if ( !p ) {
+            _document->SetError( XML_ERROR_PARSING_TEXT, _parseLineNum, 0 );
+        }
+    }
+    return 0;
+}
+
+
+XMLNode* XMLText::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLText* text = doc->NewText( Value() );	// fixme: this will always allocate memory. Intern?
+    text->SetCData( this->CData() );
+    return text;
+}
+
+
+bool XMLText::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLText* text = compare->ToText();
+    return ( text && XMLUtil::StringEqual( text->Value(), Value() ) );
+}
+
+
+bool XMLText::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+
+// --------- XMLComment ---------- //
+
+XMLComment::XMLComment( XMLDocument* doc ) : XMLNode( doc )
+{
+}
+
+
+XMLComment::~XMLComment()
+{
+}
+
+
+char* XMLComment::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
+{
+    // Comment parses as text.
+    p = _value.ParseText( p, "-->", StrPair::COMMENT, curLineNumPtr );
+    if ( p == 0 ) {
+        _document->SetError( XML_ERROR_PARSING_COMMENT, _parseLineNum, 0 );
+    }
+    return p;
+}
+
+
+XMLNode* XMLComment::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLComment* comment = doc->NewComment( Value() );	// fixme: this will always allocate memory. Intern?
+    return comment;
+}
+
+
+bool XMLComment::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLComment* comment = compare->ToComment();
+    return ( comment && XMLUtil::StringEqual( comment->Value(), Value() ));
+}
+
+
+bool XMLComment::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+
+// --------- XMLDeclaration ---------- //
+
+XMLDeclaration::XMLDeclaration( XMLDocument* doc ) : XMLNode( doc )
+{
+}
+
+
+XMLDeclaration::~XMLDeclaration()
+{
+    //printf( "~XMLDeclaration\n" );
+}
+
+
+char* XMLDeclaration::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
+{
+    // Declaration parses as text.
+    p = _value.ParseText( p, "?>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
+    if ( p == 0 ) {
+        _document->SetError( XML_ERROR_PARSING_DECLARATION, _parseLineNum, 0 );
+    }
+    return p;
+}
+
+
+XMLNode* XMLDeclaration::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLDeclaration* dec = doc->NewDeclaration( Value() );	// fixme: this will always allocate memory. Intern?
+    return dec;
+}
+
+
+bool XMLDeclaration::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLDeclaration* declaration = compare->ToDeclaration();
+    return ( declaration && XMLUtil::StringEqual( declaration->Value(), Value() ));
+}
+
+
+
+bool XMLDeclaration::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+// --------- XMLUnknown ---------- //
+
+XMLUnknown::XMLUnknown( XMLDocument* doc ) : XMLNode( doc )
+{
+}
+
+
+XMLUnknown::~XMLUnknown()
+{
+}
+
+
+char* XMLUnknown::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
+{
+    // Unknown parses as text.
+    p = _value.ParseText( p, ">", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
+    if ( !p ) {
+        _document->SetError( XML_ERROR_PARSING_UNKNOWN, _parseLineNum, 0 );
+    }
+    return p;
+}
+
+
+XMLNode* XMLUnknown::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLUnknown* text = doc->NewUnknown( Value() );	// fixme: this will always allocate memory. Intern?
+    return text;
+}
+
+
+bool XMLUnknown::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLUnknown* unknown = compare->ToUnknown();
+    return ( unknown && XMLUtil::StringEqual( unknown->Value(), Value() ));
+}
+
+
+bool XMLUnknown::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+// --------- XMLAttribute ---------- //
+
+const char* XMLAttribute::Name() const
+{
+    return _name.GetStr();
+}
+
+const char* XMLAttribute::Value() const
+{
+    return _value.GetStr();
+}
+
+char* XMLAttribute::ParseDeep( char* p, bool processEntities, int* curLineNumPtr )
+{
+    // Parse using the name rules: bug fix, was using ParseText before
+    p = _name.ParseName( p );
+    if ( !p || !*p ) {
+        return 0;
+    }
+
+    // Skip white space before =
+    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
+    if ( *p != '=' ) {
+        return 0;
+    }
+
+    ++p;	// move up to opening quote
+    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
+    if ( *p != '\"' && *p != '\'' ) {
+        return 0;
+    }
+
+    const char endTag[2] = { *p, 0 };
+    ++p;	// move past opening quote
+
+    p = _value.ParseText( p, endTag, processEntities ? StrPair::ATTRIBUTE_VALUE : StrPair::ATTRIBUTE_VALUE_LEAVE_ENTITIES, curLineNumPtr );
+    return p;
+}
+
+
+void XMLAttribute::SetName( const char* n )
+{
+    _name.SetStr( n );
+}
+
+
+XMLError XMLAttribute::QueryIntValue( int* value ) const
+{
+    if ( XMLUtil::ToInt( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryUnsignedValue( unsigned int* value ) const
+{
+    if ( XMLUtil::ToUnsigned( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryInt64Value(int64_t* value) const
+{
+	if (XMLUtil::ToInt64(Value(), value)) {
+		return XML_SUCCESS;
+	}
+	return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryUnsigned64Value(uint64_t* value) const
+{
+    if(XMLUtil::ToUnsigned64(Value(), value)) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryBoolValue( bool* value ) const
+{
+    if ( XMLUtil::ToBool( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryFloatValue( float* value ) const
+{
+    if ( XMLUtil::ToFloat( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryDoubleValue( double* value ) const
+{
+    if ( XMLUtil::ToDouble( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+void XMLAttribute::SetAttribute( const char* v )
+{
+    _value.SetStr( v );
+}
+
+
+void XMLAttribute::SetAttribute( int v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+
+void XMLAttribute::SetAttribute( unsigned v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+
+void XMLAttribute::SetAttribute(int64_t v)
+{
+	char buf[BUF_SIZE];
+	XMLUtil::ToStr(v, buf, BUF_SIZE);
+	_value.SetStr(buf);
+}
+
+void XMLAttribute::SetAttribute(uint64_t v)
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr(v, buf, BUF_SIZE);
+    _value.SetStr(buf);
+}
+
+
+void XMLAttribute::SetAttribute( bool v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+void XMLAttribute::SetAttribute( double v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+void XMLAttribute::SetAttribute( float v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+
+// --------- XMLElement ---------- //
+XMLElement::XMLElement( XMLDocument* doc ) : XMLNode( doc ),
+    _closingType( OPEN ),
+    _rootAttribute( 0 )
+{
+}
+
+
+XMLElement::~XMLElement()
+{
+    while( _rootAttribute ) {
+        XMLAttribute* next = _rootAttribute->_next;
+        DeleteAttribute( _rootAttribute );
+        _rootAttribute = next;
+    }
+}
+
+
+const XMLAttribute* XMLElement::FindAttribute( const char* name ) const
+{
+    for( XMLAttribute* a = _rootAttribute; a; a = a->_next ) {
+        if ( XMLUtil::StringEqual( a->Name(), name ) ) {
+            return a;
+        }
+    }
+    return 0;
+}
+
+
+const char* XMLElement::Attribute( const char* name, const char* value ) const
+{
+    const XMLAttribute* a = FindAttribute( name );
+    if ( !a ) {
+        return 0;
+    }
+    if ( !value || XMLUtil::StringEqual( a->Value(), value )) {
+        return a->Value();
+    }
+    return 0;
+}
+
+int XMLElement::IntAttribute(const char* name, int defaultValue) const
+{
+	int i = defaultValue;
+	QueryIntAttribute(name, &i);
+	return i;
+}
+
+unsigned XMLElement::UnsignedAttribute(const char* name, unsigned defaultValue) const
+{
+	unsigned i = defaultValue;
+	QueryUnsignedAttribute(name, &i);
+	return i;
+}
+
+int64_t XMLElement::Int64Attribute(const char* name, int64_t defaultValue) const
+{
+	int64_t i = defaultValue;
+	QueryInt64Attribute(name, &i);
+	return i;
+}
+
+uint64_t XMLElement::Unsigned64Attribute(const char* name, uint64_t defaultValue) const
+{
+	uint64_t i = defaultValue;
+	QueryUnsigned64Attribute(name, &i);
+	return i;
+}
+
+bool XMLElement::BoolAttribute(const char* name, bool defaultValue) const
+{
+	bool b = defaultValue;
+	QueryBoolAttribute(name, &b);
+	return b;
+}
+
+double XMLElement::DoubleAttribute(const char* name, double defaultValue) const
+{
+	double d = defaultValue;
+	QueryDoubleAttribute(name, &d);
+	return d;
+}
+
+float XMLElement::FloatAttribute(const char* name, float defaultValue) const
+{
+	float f = defaultValue;
+	QueryFloatAttribute(name, &f);
+	return f;
+}
+
+const char* XMLElement::GetText() const
+{
+    /* skip comment node */
+    const XMLNode* node = FirstChild();
+    while (node) {
+        if (node->ToComment()) {
+            node = node->NextSibling();
+            continue;
+        }
+        break;
+    }
+
+    if ( node && node->ToText() ) {
+        return node->Value();
+    }
+    return 0;
+}
+
+
+void	XMLElement::SetText( const char* inText )
+{
+	if ( FirstChild() && FirstChild()->ToText() )
+		FirstChild()->SetValue( inText );
+	else {
+		XMLText*	theText = GetDocument()->NewText( inText );
+		InsertFirstChild( theText );
+	}
+}
+
+
+void XMLElement::SetText( int v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText( unsigned v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText(int64_t v)
+{
+	char buf[BUF_SIZE];
+	XMLUtil::ToStr(v, buf, BUF_SIZE);
+	SetText(buf);
+}
+
+void XMLElement::SetText(uint64_t v) {
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr(v, buf, BUF_SIZE);
+    SetText(buf);
+}
+
+
+void XMLElement::SetText( bool v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText( float v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText( double v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+XMLError XMLElement::QueryIntText( int* ival ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToInt( t, ival ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryUnsignedText( unsigned* uval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToUnsigned( t, uval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryInt64Text(int64_t* ival) const
+{
+	if (FirstChild() && FirstChild()->ToText()) {
+		const char* t = FirstChild()->Value();
+		if (XMLUtil::ToInt64(t, ival)) {
+			return XML_SUCCESS;
+		}
+		return XML_CAN_NOT_CONVERT_TEXT;
+	}
+	return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryUnsigned64Text(uint64_t* uval) const
+{
+    if(FirstChild() && FirstChild()->ToText()) {
+        const char* t = FirstChild()->Value();
+        if(XMLUtil::ToUnsigned64(t, uval)) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryBoolText( bool* bval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToBool( t, bval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryDoubleText( double* dval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToDouble( t, dval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryFloatText( float* fval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToFloat( t, fval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+int XMLElement::IntText(int defaultValue) const
+{
+	int i = defaultValue;
+	QueryIntText(&i);
+	return i;
+}
+
+unsigned XMLElement::UnsignedText(unsigned defaultValue) const
+{
+	unsigned i = defaultValue;
+	QueryUnsignedText(&i);
+	return i;
+}
+
+int64_t XMLElement::Int64Text(int64_t defaultValue) const
+{
+	int64_t i = defaultValue;
+	QueryInt64Text(&i);
+	return i;
+}
+
+uint64_t XMLElement::Unsigned64Text(uint64_t defaultValue) const
+{
+	uint64_t i = defaultValue;
+	QueryUnsigned64Text(&i);
+	return i;
+}
+
+bool XMLElement::BoolText(bool defaultValue) const
+{
+	bool b = defaultValue;
+	QueryBoolText(&b);
+	return b;
+}
+
+double XMLElement::DoubleText(double defaultValue) const
+{
+	double d = defaultValue;
+	QueryDoubleText(&d);
+	return d;
+}
+
+float XMLElement::FloatText(float defaultValue) const
+{
+	float f = defaultValue;
+	QueryFloatText(&f);
+	return f;
+}
+
+
+XMLAttribute* XMLElement::FindOrCreateAttribute( const char* name )
+{
+    XMLAttribute* last = 0;
+    XMLAttribute* attrib = 0;
+    for( attrib = _rootAttribute;
+            attrib;
+            last = attrib, attrib = attrib->_next ) {
+        if ( XMLUtil::StringEqual( attrib->Name(), name ) ) {
+            break;
+        }
+    }
+    if ( !attrib ) {
+        attrib = CreateAttribute();
+        TIXMLASSERT( attrib );
+        if ( last ) {
+            TIXMLASSERT( last->_next == 0 );
+            last->_next = attrib;
+        }
+        else {
+            TIXMLASSERT( _rootAttribute == 0 );
+            _rootAttribute = attrib;
+        }
+        attrib->SetName( name );
+    }
+    return attrib;
+}
+
+
+void XMLElement::DeleteAttribute( const char* name )
+{
+    XMLAttribute* prev = 0;
+    for( XMLAttribute* a=_rootAttribute; a; a=a->_next ) {
+        if ( XMLUtil::StringEqual( name, a->Name() ) ) {
+            if ( prev ) {
+                prev->_next = a->_next;
+            }
+            else {
+                _rootAttribute = a->_next;
+            }
+            DeleteAttribute( a );
+            break;
+        }
+        prev = a;
+    }
+}
+
+
+char* XMLElement::ParseAttributes( char* p, int* curLineNumPtr )
+{
+    XMLAttribute* prevAttribute = 0;
+
+    // Read the attributes.
+    while( p ) {
+        p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
+        if ( !(*p) ) {
+            _document->SetError( XML_ERROR_PARSING_ELEMENT, _parseLineNum, "XMLElement name=%s", Name() );
+            return 0;
+        }
+
+        // attribute.
+        if (XMLUtil::IsNameStartChar( static_cast<unsigned char>(*p) ) ) {
+            XMLAttribute* attrib = CreateAttribute();
+            TIXMLASSERT( attrib );
+            attrib->_parseLineNum = _document->_parseCurLineNum;
+
+            const int attrLineNum = attrib->_parseLineNum;
+
+            p = attrib->ParseDeep( p, _document->ProcessEntities(), curLineNumPtr );
+            if ( !p || Attribute( attrib->Name() ) ) {
+                DeleteAttribute( attrib );
+                _document->SetError( XML_ERROR_PARSING_ATTRIBUTE, attrLineNum, "XMLElement name=%s", Name() );
+                return 0;
+            }
+            // There is a minor bug here: if the attribute in the source xml
+            // document is duplicated, it will not be detected and the
+            // attribute will be doubly added. However, tracking the 'prevAttribute'
+            // avoids re-scanning the attribute list. Preferring performance for
+            // now, may reconsider in the future.
+            if ( prevAttribute ) {
+                TIXMLASSERT( prevAttribute->_next == 0 );
+                prevAttribute->_next = attrib;
+            }
+            else {
+                TIXMLASSERT( _rootAttribute == 0 );
+                _rootAttribute = attrib;
+            }
+            prevAttribute = attrib;
+        }
+        // end of the tag
+        else if ( *p == '>' ) {
+            ++p;
+            break;
+        }
+        // end of the tag
+        else if ( *p == '/' && *(p+1) == '>' ) {
+            _closingType = CLOSED;
+            return p+2;	// done; sealed element.
+        }
+        else {
+            _document->SetError( XML_ERROR_PARSING_ELEMENT, _parseLineNum, 0 );
+            return 0;
+        }
+    }
+    return p;
+}
+
+void XMLElement::DeleteAttribute( XMLAttribute* attribute )
+{
+    if ( attribute == 0 ) {
+        return;
+    }
+    MemPool* pool = attribute->_memPool;
+    attribute->~XMLAttribute();
+    pool->Free( attribute );
+}
+
+XMLAttribute* XMLElement::CreateAttribute()
+{
+    TIXMLASSERT( sizeof( XMLAttribute ) == _document->_attributePool.ItemSize() );
+    XMLAttribute* attrib = new (_document->_attributePool.Alloc() ) XMLAttribute();
+    TIXMLASSERT( attrib );
+    attrib->_memPool = &_document->_attributePool;
+    attrib->_memPool->SetTracked();
+    return attrib;
+}
+
+
+XMLElement* XMLElement::InsertNewChildElement(const char* name)
+{
+    XMLElement* node = _document->NewElement(name);
+    return InsertEndChild(node) ? node : 0;
+}
+
+XMLComment* XMLElement::InsertNewComment(const char* comment)
+{
+    XMLComment* node = _document->NewComment(comment);
+    return InsertEndChild(node) ? node : 0;
+}
+
+XMLText* XMLElement::InsertNewText(const char* text)
+{
+    XMLText* node = _document->NewText(text);
+    return InsertEndChild(node) ? node : 0;
+}
+
+XMLDeclaration* XMLElement::InsertNewDeclaration(const char* text)
+{
+    XMLDeclaration* node = _document->NewDeclaration(text);
+    return InsertEndChild(node) ? node : 0;
+}
+
+XMLUnknown* XMLElement::InsertNewUnknown(const char* text)
+{
+    XMLUnknown* node = _document->NewUnknown(text);
+    return InsertEndChild(node) ? node : 0;
+}
+
+
+
+//
+//	<ele></ele>
+//	<ele>foo<b>bar</b></ele>
+//
+char* XMLElement::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
+{
+    // Read the element name.
+    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
+
+    // The closing element is the </element> form. It is
+    // parsed just like a regular element then deleted from
+    // the DOM.
+    if ( *p == '/' ) {
+        _closingType = CLOSING;
+        ++p;
+    }
+
+    p = _value.ParseName( p );
+    if ( _value.Empty() ) {
+        return 0;
+    }
+
+    p = ParseAttributes( p, curLineNumPtr );
+    if ( !p || !*p || _closingType != OPEN ) {
+        return p;
+    }
+
+    p = XMLNode::ParseDeep( p, parentEndTag, curLineNumPtr );
+    return p;
+}
+
+
+
+XMLNode* XMLElement::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLElement* element = doc->NewElement( Value() );					// fixme: this will always allocate memory. Intern?
+    for( const XMLAttribute* a=FirstAttribute(); a; a=a->Next() ) {
+        element->SetAttribute( a->Name(), a->Value() );					// fixme: this will always allocate memory. Intern?
+    }
+    return element;
+}
+
+
+bool XMLElement::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLElement* other = compare->ToElement();
+    if ( other && XMLUtil::StringEqual( other->Name(), Name() )) {
+
+        const XMLAttribute* a=FirstAttribute();
+        const XMLAttribute* b=other->FirstAttribute();
+
+        while ( a && b ) {
+            if ( !XMLUtil::StringEqual( a->Value(), b->Value() ) ) {
+                return false;
+            }
+            a = a->Next();
+            b = b->Next();
+        }
+        if ( a || b ) {
+            // different count
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+
+bool XMLElement::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    if ( visitor->VisitEnter( *this, _rootAttribute ) ) {
+        for ( const XMLNode* node=FirstChild(); node; node=node->NextSibling() ) {
+            if ( !node->Accept( visitor ) ) {
+                break;
+            }
+        }
+    }
+    return visitor->VisitExit( *this );
+}
+
+
+// --------- XMLDocument ----------- //
+
+// Warning: List must match 'enum XMLError'
+const char* XMLDocument::_errorNames[XML_ERROR_COUNT] = {
+    "XML_SUCCESS",
+    "XML_NO_ATTRIBUTE",
+    "XML_WRONG_ATTRIBUTE_TYPE",
+    "XML_ERROR_FILE_NOT_FOUND",
+    "XML_ERROR_FILE_COULD_NOT_BE_OPENED",
+    "XML_ERROR_FILE_READ_ERROR",
+    "XML_ERROR_PARSING_ELEMENT",
+    "XML_ERROR_PARSING_ATTRIBUTE",
+    "XML_ERROR_PARSING_TEXT",
+    "XML_ERROR_PARSING_CDATA",
+    "XML_ERROR_PARSING_COMMENT",
+    "XML_ERROR_PARSING_DECLARATION",
+    "XML_ERROR_PARSING_UNKNOWN",
+    "XML_ERROR_EMPTY_DOCUMENT",
+    "XML_ERROR_MISMATCHED_ELEMENT",
+    "XML_ERROR_PARSING",
+    "XML_CAN_NOT_CONVERT_TEXT",
+    "XML_NO_TEXT_NODE",
+	"XML_ELEMENT_DEPTH_EXCEEDED"
+};
+
+
+XMLDocument::XMLDocument( bool processEntities, Whitespace whitespaceMode ) :
+    XMLNode( 0 ),
+    _writeBOM( false ),
+    _processEntities( processEntities ),
+    _errorID(XML_SUCCESS),
+    _whitespaceMode( whitespaceMode ),
+    _errorStr(),
+    _errorLineNum( 0 ),
+    _charBuffer( 0 ),
+    _parseCurLineNum( 0 ),
+	_parsingDepth(0),
+    _unlinked(),
+    _elementPool(),
+    _attributePool(),
+    _textPool(),
+    _commentPool()
+{
+    // avoid VC++ C4355 warning about 'this' in initializer list (C4355 is off by default in VS2012+)
+    _document = this;
+}
+
+
+XMLDocument::~XMLDocument()
+{
+    Clear();
+}
+
+
+void XMLDocument::MarkInUse(const XMLNode* const node)
+{
+	TIXMLASSERT(node);
+	TIXMLASSERT(node->_parent == 0);
+
+	for (size_t i = 0; i < _unlinked.Size(); ++i) {
+		if (node == _unlinked[i]) {
+			_unlinked.SwapRemove(i);
+			break;
+		}
+	}
+}
+
+void XMLDocument::Clear()
+{
+    DeleteChildren();
+	while( _unlinked.Size()) {
+		DeleteNode(_unlinked[0]);	// Will remove from _unlinked as part of delete.
+	}
+
+#ifdef TINYXML2_DEBUG
+    const bool hadError = Error();
+#endif
+    ClearError();
+
+    delete [] _charBuffer;
+    _charBuffer = 0;
+	_parsingDepth = 0;
+
+#if 0
+    _textPool.Trace( "text" );
+    _elementPool.Trace( "element" );
+    _commentPool.Trace( "comment" );
+    _attributePool.Trace( "attribute" );
+#endif
+
+#ifdef TINYXML2_DEBUG
+    if ( !hadError ) {
+        TIXMLASSERT( _elementPool.CurrentAllocs()   == _elementPool.Untracked() );
+        TIXMLASSERT( _attributePool.CurrentAllocs() == _attributePool.Untracked() );
+        TIXMLASSERT( _textPool.CurrentAllocs()      == _textPool.Untracked() );
+        TIXMLASSERT( _commentPool.CurrentAllocs()   == _commentPool.Untracked() );
+    }
+#endif
+}
+
+
+void XMLDocument::DeepCopy(XMLDocument* target) const
+{
+	TIXMLASSERT(target);
+    if (target == this) {
+        return; // technically success - a no-op.
+    }
+
+	target->Clear();
+	for (const XMLNode* node = this->FirstChild(); node; node = node->NextSibling()) {
+		target->InsertEndChild(node->DeepClone(target));
+	}
+}
+
+XMLElement* XMLDocument::NewElement( const char* name )
+{
+    XMLElement* ele = CreateUnlinkedNode<XMLElement>( _elementPool );
+    ele->SetName( name );
+    return ele;
+}
+
+
+XMLComment* XMLDocument::NewComment( const char* str )
+{
+    XMLComment* comment = CreateUnlinkedNode<XMLComment>( _commentPool );
+    comment->SetValue( str );
+    return comment;
+}
+
+
+XMLText* XMLDocument::NewText( const char* str )
+{
+    XMLText* text = CreateUnlinkedNode<XMLText>( _textPool );
+    text->SetValue( str );
+    return text;
+}
+
+
+XMLDeclaration* XMLDocument::NewDeclaration( const char* str )
+{
+    XMLDeclaration* dec = CreateUnlinkedNode<XMLDeclaration>( _commentPool );
+    dec->SetValue( str ? str : "xml version=\"1.0\" encoding=\"UTF-8\"" );
+    return dec;
+}
+
+
+XMLUnknown* XMLDocument::NewUnknown( const char* str )
+{
+    XMLUnknown* unk = CreateUnlinkedNode<XMLUnknown>( _commentPool );
+    unk->SetValue( str );
+    return unk;
+}
+
+static FILE* callfopen( const char* filepath, const char* mode )
+{
+    TIXMLASSERT( filepath );
+    TIXMLASSERT( mode );
+#if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
+    FILE* fp = 0;
+    const errno_t err = fopen_s( &fp, filepath, mode );
+    if ( err ) {
+        return 0;
+    }
+#else
+    FILE* fp = fopen( filepath, mode );
+#endif
+    return fp;
+}
+
+void XMLDocument::DeleteNode( XMLNode* node )	{
+    TIXMLASSERT( node );
+    TIXMLASSERT(node->_document == this );
+    if (node->_parent) {
+        node->_parent->DeleteChild( node );
+    }
+    else {
+        // Isn't in the tree.
+        // Use the parent delete.
+        // Also, we need to mark it tracked: we 'know'
+        // it was never used.
+        node->_memPool->SetTracked();
+        // Call the static XMLNode version:
+        XMLNode::DeleteNode(node);
+    }
+}
+
+
+XMLError XMLDocument::LoadFile( const char* filename )
+{
+    if ( !filename ) {
+        TIXMLASSERT( false );
+        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>" );
+        return _errorID;
+    }
+
+    Clear();
+    FILE* fp = callfopen( filename, "rb" );
+    if ( !fp ) {
+        SetError( XML_ERROR_FILE_NOT_FOUND, 0, "filename=%s", filename );
+        return _errorID;
+    }
+    LoadFile( fp );
+    fclose( fp );
+    return _errorID;
+}
+
+XMLError XMLDocument::LoadFile( FILE* fp )
+{
+    Clear();
+
+    TIXML_FSEEK( fp, 0, SEEK_SET );
+    if ( fgetc( fp ) == EOF && ferror( fp ) != 0 ) {
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+
+    TIXML_FSEEK( fp, 0, SEEK_END );
+
+    unsigned long long filelength;
+    {
+        const long long fileLengthSigned = TIXML_FTELL( fp );
+        TIXML_FSEEK( fp, 0, SEEK_SET );
+        if ( fileLengthSigned == -1L ) {
+            SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+            return _errorID;
+        }
+        TIXMLASSERT( fileLengthSigned >= 0 );
+        filelength = static_cast<unsigned long long>(fileLengthSigned);
+    }
+
+    const size_t maxSizeT = static_cast<size_t>(-1);
+    // We'll do the comparison as an unsigned long long, because that's guaranteed to be at
+    // least 8 bytes, even on a 32-bit platform.
+    if ( filelength >= static_cast<unsigned long long>(maxSizeT) ) {
+        // Cannot handle files which won't fit in buffer together with null terminator
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+
+    if ( filelength == 0 ) {
+        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
+        return _errorID;
+    }
+
+    const size_t size = static_cast<size_t>(filelength);
+    TIXMLASSERT( _charBuffer == 0 );
+    _charBuffer = new char[size+1];
+    const size_t read = fread( _charBuffer, 1, size, fp );
+    if ( read != size ) {
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+
+    _charBuffer[size] = 0;
+
+    Parse();
+    return _errorID;
+}
+
+
+XMLError XMLDocument::SaveFile( const char* filename, bool compact )
+{
+    if ( !filename ) {
+        TIXMLASSERT( false );
+        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>" );
+        return _errorID;
+    }
+
+    FILE* fp = callfopen( filename, "w" );
+    if ( !fp ) {
+        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=%s", filename );
+        return _errorID;
+    }
+    SaveFile(fp, compact);
+    fclose( fp );
+    return _errorID;
+}
+
+
+XMLError XMLDocument::SaveFile( FILE* fp, bool compact )
+{
+    // Clear any error from the last save, otherwise it will get reported
+    // for *this* call.
+    ClearError();
+    XMLPrinter stream( fp, compact );
+    Print( &stream );
+    return _errorID;
+}
+
+
+XMLError XMLDocument::Parse( const char* xml, size_t nBytes )
+{
+    Clear();
+
+    if ( nBytes == 0 || !xml || !*xml ) {
+        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
+        return _errorID;
+    }
+    if ( nBytes == static_cast<size_t>(-1) ) {
+        nBytes = strlen( xml );
+    }
+    TIXMLASSERT( _charBuffer == 0 );
+    _charBuffer = new char[ nBytes+1 ];
+    memcpy( _charBuffer, xml, nBytes );
+    _charBuffer[nBytes] = 0;
+
+    Parse();
+    if ( Error() ) {
+        // clean up now essentially dangling memory.
+        // and the parse fail can put objects in the
+        // pools that are dead and inaccessible.
+        DeleteChildren();
+        _elementPool.Clear();
+        _attributePool.Clear();
+        _textPool.Clear();
+        _commentPool.Clear();
+    }
+    return _errorID;
+}
+
+
+void XMLDocument::Print( XMLPrinter* streamer ) const
+{
+    if ( streamer ) {
+        Accept( streamer );
+    }
+    else {
+        XMLPrinter stdoutStreamer( stdout );
+        Accept( &stdoutStreamer );
+    }
+}
+
+
+void XMLDocument::ClearError() {
+    _errorID = XML_SUCCESS;
+    _errorLineNum = 0;
+    _errorStr.Reset();
+}
+
+
+void XMLDocument::SetError( XMLError error, int lineNum, const char* format, ... )
+{
+    TIXMLASSERT(error >= 0 && error < XML_ERROR_COUNT);
+    _errorID = error;
+    _errorLineNum = lineNum;
+	_errorStr.Reset();
+
+    const size_t BUFFER_SIZE = 1000;
+    char* buffer = new char[BUFFER_SIZE];
+
+    TIXMLASSERT(sizeof(error) <= sizeof(int));
+    TIXML_SNPRINTF(buffer, BUFFER_SIZE, "Error=%s ErrorID=%d (0x%x) Line number=%d",
+        ErrorIDToName(error), static_cast<int>(error), static_cast<unsigned int>(error), lineNum);
+
+	if (format) {
+		size_t len = strlen(buffer);
+		TIXML_SNPRINTF(buffer + len, BUFFER_SIZE - len, ": ");
+		len = strlen(buffer);
+
+		va_list va;
+		va_start(va, format);
+		TIXML_VSNPRINTF(buffer + len, BUFFER_SIZE - len, format, va);
+		va_end(va);
+	}
+	_errorStr.SetStr(buffer);
+	delete[] buffer;
+}
+
+
+/*static*/ const char* XMLDocument::ErrorIDToName(XMLError errorID)
+{
+	TIXMLASSERT( errorID >= 0 && errorID < XML_ERROR_COUNT );
+    const char* errorName = _errorNames[errorID];
+    TIXMLASSERT( errorName && errorName[0] );
+    return errorName;
+}
+
+const char* XMLDocument::ErrorStr() const
+{
+	return _errorStr.Empty() ? "" : _errorStr.GetStr();
+}
+
+
+void XMLDocument::PrintError() const
+{
+    printf("%s\n", ErrorStr());
+}
+
+const char* XMLDocument::ErrorName() const
+{
+    return ErrorIDToName(_errorID);
+}
+
+void XMLDocument::Parse()
+{
+    TIXMLASSERT( NoChildren() ); // Clear() must have been called previously
+    TIXMLASSERT( _charBuffer );
+    _parseCurLineNum = 1;
+    _parseLineNum = 1;
+    char* p = _charBuffer;
+    p = XMLUtil::SkipWhiteSpace( p, &_parseCurLineNum );
+    p = const_cast<char*>( XMLUtil::ReadBOM( p, &_writeBOM ) );
+    if ( !*p ) {
+        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
+        return;
+    }
+    ParseDeep(p, 0, &_parseCurLineNum );
+}
+
+void XMLDocument::PushDepth()
+{
+	_parsingDepth++;
+	if (_parsingDepth == TINYXML2_MAX_ELEMENT_DEPTH) {
+		SetError(XML_ELEMENT_DEPTH_EXCEEDED, _parseCurLineNum, "Element nesting is too deep." );
+	}
+}
+
+void XMLDocument::PopDepth()
+{
+	TIXMLASSERT(_parsingDepth > 0);
+	--_parsingDepth;
+}
+
+XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
+    _elementJustOpened( false ),
+    _stack(),
+    _firstElement( true ),
+    _fp( file ),
+    _depth( depth ),
+    _textDepth( -1 ),
+    _processEntities( true ),
+    _compactMode( compact ),
+    _buffer()
+{
+    for( int i=0; i<ENTITY_RANGE; ++i ) {
+        _entityFlag[i] = false;
+        _restrictedEntityFlag[i] = false;
+    }
+    for( int i=0; i<NUM_ENTITIES; ++i ) {
+        const char entityValue = entities[i].value;
+        const unsigned char flagIndex = static_cast<unsigned char>(entityValue);
+        TIXMLASSERT( flagIndex < ENTITY_RANGE );
+        _entityFlag[flagIndex] = true;
+    }
+    _restrictedEntityFlag[static_cast<unsigned char>('&')] = true;
+    _restrictedEntityFlag[static_cast<unsigned char>('<')] = true;
+    _restrictedEntityFlag[static_cast<unsigned char>('>')] = true;	// not required, but consistency is nice
+    _buffer.Push( 0 );
+}
+
+
+void XMLPrinter::Print( const char* format, ... )
+{
+    va_list     va;
+    va_start( va, format );
+
+    if ( _fp ) {
+        vfprintf( _fp, format, va );
+    }
+    else {
+        const int len = TIXML_VSCPRINTF( format, va );
+        // Close out and re-start the va-args
+        va_end( va );
+        TIXMLASSERT( len >= 0 );
+        va_start( va, format );
+        TIXMLASSERT( _buffer.Size() > 0 && _buffer[_buffer.Size() - 1] == 0 );
+        char* p = _buffer.PushArr( len ) - 1;	// back up over the null terminator.
+		TIXML_VSNPRINTF( p, len+1, format, va );
+    }
+    va_end( va );
+}
+
+
+void XMLPrinter::Write( const char* data, size_t size )
+{
+    if ( _fp ) {
+        fwrite ( data , sizeof(char), size, _fp);
+    }
+    else {
+        char* p = _buffer.PushArr( static_cast<int>(size) ) - 1;   // back up over the null terminator.
+        memcpy( p, data, size );
+        p[size] = 0;
+    }
+}
+
+
+void XMLPrinter::Putc( char ch )
+{
+    if ( _fp ) {
+        fputc ( ch, _fp);
+    }
+    else {
+        char* p = _buffer.PushArr( sizeof(char) ) - 1;   // back up over the null terminator.
+        p[0] = ch;
+        p[1] = 0;
+    }
+}
+
+
+void XMLPrinter::PrintSpace( int depth )
+{
+    for( int i=0; i<depth; ++i ) {
+        Write( "    " );
+    }
+}
+
+
+void XMLPrinter::PrintString( const char* p, bool restricted )
+{
+    // Look for runs of bytes between entities to print.
+    const char* q = p;
+
+    if ( _processEntities ) {
+        const bool* flag = restricted ? _restrictedEntityFlag : _entityFlag;
+        while ( *q ) {
+            TIXMLASSERT( p <= q );
+            // Remember, char is sometimes signed. (How many times has that bitten me?)
+            if ( *q > 0 && *q < ENTITY_RANGE ) {
+                // Check for entities. If one is found, flush
+                // the stream up until the entity, write the
+                // entity, and keep looking.
+                if ( flag[static_cast<unsigned char>(*q)] ) {
+                    while ( p < q ) {
+                        const size_t delta = q - p;
+                        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : static_cast<int>(delta);
+                        Write( p, toPrint );
+                        p += toPrint;
+                    }
+                    bool entityPatternPrinted = false;
+                    for( int i=0; i<NUM_ENTITIES; ++i ) {
+                        if ( entities[i].value == *q ) {
+                            Putc( '&' );
+                            Write( entities[i].pattern, entities[i].length );
+                            Putc( ';' );
+                            entityPatternPrinted = true;
+                            break;
+                        }
+                    }
+                    if ( !entityPatternPrinted ) {
+                        // TIXMLASSERT( entityPatternPrinted ) causes gcc -Wunused-but-set-variable in release
+                        TIXMLASSERT( false );
+                    }
+                    ++p;
+                }
+            }
+            ++q;
+            TIXMLASSERT( p <= q );
+        }
+        // Flush the remaining string. This will be the entire
+        // string if an entity wasn't found.
+        if ( p < q ) {
+            const size_t delta = q - p;
+            const int toPrint = ( INT_MAX < delta ) ? INT_MAX : static_cast<int>(delta);
+            Write( p, toPrint );
+        }
+    }
+    else {
+        Write( p );
+    }
+}
+
+
+void XMLPrinter::PushHeader( bool writeBOM, bool writeDec )
+{
+    if ( writeBOM ) {
+        static const unsigned char bom[] = { TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1, TIXML_UTF_LEAD_2, 0 };
+        Write( reinterpret_cast< const char* >( bom ) );
+    }
+    if ( writeDec ) {
+        PushDeclaration( "xml version=\"1.0\"" );
+    }
+}
+
+void XMLPrinter::PrepareForNewNode( bool compactMode )
+{
+    SealElementIfJustOpened();
+
+    if ( compactMode ) {
+        return;
+    }
+
+    if ( _firstElement ) {
+        PrintSpace (_depth);
+    } else if ( _textDepth < 0) {
+        Putc( '\n' );
+        PrintSpace( _depth );
+    }
+
+    _firstElement = false;
+}
+
+void XMLPrinter::OpenElement( const char* name, bool compactMode )
+{
+    PrepareForNewNode( compactMode );
+    _stack.Push( name );
+
+    Write ( "<" );
+    Write ( name );
+
+    _elementJustOpened = true;
+    ++_depth;
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, const char* value )
+{
+    TIXMLASSERT( _elementJustOpened );
+    Putc ( ' ' );
+    Write( name );
+    Write( "=\"" );
+    PrintString( value, false );
+    Putc ( '\"' );
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, int v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, unsigned v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::PushAttribute(const char* name, int64_t v)
+{
+	char buf[BUF_SIZE];
+	XMLUtil::ToStr(v, buf, BUF_SIZE);
+	PushAttribute(name, buf);
+}
+
+
+void XMLPrinter::PushAttribute(const char* name, uint64_t v)
+{
+	char buf[BUF_SIZE];
+	XMLUtil::ToStr(v, buf, BUF_SIZE);
+	PushAttribute(name, buf);
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, bool v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, double v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::CloseElement( bool compactMode )
+{
+    --_depth;
+    const char* name = _stack.Pop();
+
+    if ( _elementJustOpened ) {
+        Write( "/>" );
+    }
+    else {
+        if ( _textDepth < 0 && !compactMode) {
+            Putc( '\n' );
+            PrintSpace( _depth );
+        }
+        Write ( "</" );
+        Write ( name );
+        Write ( ">" );
+    }
+
+    if ( _textDepth == _depth ) {
+        _textDepth = -1;
+    }
+    if ( _depth == 0 && !compactMode) {
+        Putc( '\n' );
+    }
+    _elementJustOpened = false;
+}
+
+
+void XMLPrinter::SealElementIfJustOpened()
+{
+    if ( !_elementJustOpened ) {
+        return;
+    }
+    _elementJustOpened = false;
+    Putc( '>' );
+}
+
+
+void XMLPrinter::PushText( const char* text, bool cdata )
+{
+    _textDepth = _depth-1;
+
+    SealElementIfJustOpened();
+    if ( cdata ) {
+        Write( "<![CDATA[" );
+        Write( text );
+        Write( "]]>" );
+    }
+    else {
+        PrintString( text, true );
+    }
+}
+
+
+void XMLPrinter::PushText( int64_t value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( uint64_t value )
+{
+	char buf[BUF_SIZE];
+	XMLUtil::ToStr(value, buf, BUF_SIZE);
+	PushText(buf, false);
+}
+
+
+void XMLPrinter::PushText( int value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( unsigned value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( bool value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( float value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( double value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushComment( const char* comment )
+{
+    PrepareForNewNode( _compactMode );
+
+    Write( "<!--" );
+    Write( comment );
+    Write( "-->" );
+}
+
+
+void XMLPrinter::PushDeclaration( const char* value )
+{
+    PrepareForNewNode( _compactMode );
+
+    Write( "<?" );
+    Write( value );
+    Write( "?>" );
+}
+
+
+void XMLPrinter::PushUnknown( const char* value )
+{
+    PrepareForNewNode( _compactMode );
+
+    Write( "<!" );
+    Write( value );
+    Putc( '>' );
+}
+
+
+bool XMLPrinter::VisitEnter( const XMLDocument& doc )
+{
+    _processEntities = doc.ProcessEntities();
+    if ( doc.HasBOM() ) {
+        PushHeader( true, false );
+    }
+    return true;
+}
+
+
+bool XMLPrinter::VisitEnter( const XMLElement& element, const XMLAttribute* attribute )
+{
+    const XMLElement* parentElem = 0;
+    if ( element.Parent() ) {
+        parentElem = element.Parent()->ToElement();
+    }
+    const bool compactMode = parentElem ? CompactMode( *parentElem ) : _compactMode;
+    OpenElement( element.Name(), compactMode );
+    while ( attribute ) {
+        PushAttribute( attribute->Name(), attribute->Value() );
+        attribute = attribute->Next();
+    }
+    return true;
+}
+
+
+bool XMLPrinter::VisitExit( const XMLElement& element )
+{
+    CloseElement( CompactMode(element) );
+    return true;
+}
+
+
+bool XMLPrinter::Visit( const XMLText& text )
+{
+    PushText( text.Value(), text.CData() );
+    return true;
+}
+
+
+bool XMLPrinter::Visit( const XMLComment& comment )
+{
+    PushComment( comment.Value() );
+    return true;
+}
+
+bool XMLPrinter::Visit( const XMLDeclaration& declaration )
+{
+    PushDeclaration( declaration.Value() );
+    return true;
+}
+
+
+bool XMLPrinter::Visit( const XMLUnknown& unknown )
+{
+    PushUnknown( unknown.Value() );
+    return true;
+}
+
+}   // namespace tinyxml2
+
+#if defined(_MSC_VER)
+#   pragma warning(pop)
+#endif
+
+#endif // TINYXML2_COMBINDED

--- a/tinyxml2.hpp
+++ b/tinyxml2.hpp
@@ -1,4 +1,9 @@
 /*
+
+2025 - This is an modified version by Kalana Ratnayake by combining original
+header file and cpp file into a single header only file for easier
+integration into ROS related projects.
+
 Original code by Lee Thomason (www.grinninglizard.com)
 
 This software is provided 'as-is', without any express or implied
@@ -19,12 +24,6 @@ must not be misrepresented as being the original software.
 
 3. This notice may not be removed or altered from any source
 distribution.
-*/
-
-/*
-This is an modified version by Kalana Ratnayake by combining original
-header file and cpp file into a single header only file for easier
-integration into ROS related projects
 */
 
 #ifndef TINYXML2_COMBINDED

--- a/xmltest2.cpp
+++ b/xmltest2.cpp
@@ -1,0 +1,2772 @@
+#if defined( _MSC_VER )
+	#if !defined( _CRT_SECURE_NO_WARNINGS )
+		#define _CRT_SECURE_NO_WARNINGS		// This test file is not intended to be secure.
+	#endif
+#endif
+
+#include "tinyxml2.hpp"
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
+#if defined( _MSC_VER ) || defined (WIN32)
+	#include <crtdbg.h>
+	#define WIN32_LEAN_AND_MEAN
+	#include <windows.h>
+	_CrtMemState startMemState;
+	_CrtMemState endMemState;
+#else
+	#include <sys/stat.h>
+	#include <sys/types.h>
+#endif
+
+using namespace tinyxml2;
+using namespace std;
+int gPass = 0;
+int gFail = 0;
+
+
+bool XMLTest (const char* testString, const char* expected, const char* found, bool echo=true, bool extraNL=false )
+{
+	bool pass;
+	if ( !expected && !found )
+		pass = true;
+	else if ( !expected || !found )
+		pass = false;
+	else
+		pass = !strcmp( expected, found );
+	if ( pass )
+		printf ("[pass]");
+	else
+		printf ("[fail]");
+
+	if ( !echo ) {
+		printf (" %s\n", testString);
+	}
+	else {
+		if ( extraNL ) {
+			printf( " %s\n", testString );
+			printf( "%s\n", expected );
+			printf( "%s\n", found );
+		}
+		else {
+			printf (" %s [%s][%s]\n", testString, expected, found);
+		}
+	}
+
+	if ( pass )
+		++gPass;
+	else
+		++gFail;
+	return pass;
+}
+
+bool XMLTest(const char* testString, XMLError expected, XMLError found, bool echo = true, bool extraNL = false)
+{
+    return XMLTest(testString, XMLDocument::ErrorIDToName(expected), XMLDocument::ErrorIDToName(found), echo, extraNL);
+}
+
+bool XMLTest(const char* testString, bool expected, bool found, bool echo = true, bool extraNL = false)
+{
+    return XMLTest(testString, expected ? "true" : "false", found ? "true" : "false", echo, extraNL);
+}
+
+template< class T > bool XMLTest( const char* testString, T expected, T found, bool echo=true )
+{
+	bool pass = ( expected == found );
+	if ( pass )
+		printf ("[pass]");
+	else
+		printf ("[fail]");
+
+	if ( !echo )
+		printf (" %s\n", testString);
+	else {
+		char expectedAsString[64];
+		XMLUtil::ToStr(expected, expectedAsString, sizeof(expectedAsString));
+
+		char foundAsString[64];
+		XMLUtil::ToStr(found, foundAsString, sizeof(foundAsString));
+
+		printf (" %s [%s][%s]\n", testString, expectedAsString, foundAsString );
+	}
+
+	if ( pass )
+		++gPass;
+	else
+		++gFail;
+	return pass;
+}
+
+
+void NullLineEndings( char* p )
+{
+	while( p && *p ) {
+		if ( *p == '\n' || *p == '\r' ) {
+			*p = 0;
+			return;
+		}
+		++p;
+	}
+}
+
+
+int example_1()
+{
+	XMLDocument doc;
+	doc.LoadFile( "resources/dream.xml" );
+
+	return doc.ErrorID();
+}
+/** @page Example_1 Load an XML File
+ *  @dontinclude ./xmltest.cpp
+ *  Basic XML file loading.
+ *  The basic syntax to load an XML file from
+ *  disk and check for an error. (ErrorID()
+ *  will return 0 for no error.)
+ *  @skip example_1()
+ *  @until }
+ */
+
+
+int example_2()
+{
+	static const char* xml = "<element/>";
+	XMLDocument doc;
+	doc.Parse( xml );
+
+	return doc.ErrorID();
+}
+/** @page Example_2 Parse an XML from char buffer
+ *  @dontinclude ./xmltest.cpp
+ *  Basic XML string parsing.
+ *  The basic syntax to parse an XML for
+ *  a char* and check for an error. (ErrorID()
+ *  will return 0 for no error.)
+ *  @skip example_2()
+ *  @until }
+ */
+
+
+int example_3()
+{
+	static const char* xml =
+		"<?xml version=\"1.0\"?>"
+		"<!DOCTYPE PLAY SYSTEM \"play.dtd\">"
+		"<PLAY>"
+		"<TITLE>A Midsummer Night's Dream</TITLE>"
+		"</PLAY>";
+
+	XMLDocument doc;
+	doc.Parse( xml );
+
+	XMLElement* titleElement = doc.FirstChildElement( "PLAY" )->FirstChildElement( "TITLE" );
+	const char* title = titleElement->GetText();
+	printf( "Name of play (1): %s\n", title );
+
+	XMLText* textNode = titleElement->FirstChild()->ToText();
+	title = textNode->Value();
+	printf( "Name of play (2): %s\n", title );
+
+	return doc.ErrorID();
+}
+/** @page Example_3 Get information out of XML
+	@dontinclude ./xmltest.cpp
+	In this example, we navigate a simple XML
+	file, and read some interesting text. Note
+	that this example doesn't use error
+	checking; working code should check for null
+	pointers when walking an XML tree, or use
+	XMLHandle.
+
+	(The XML is an excerpt from "dream.xml").
+
+	@skip example_3()
+	@until </PLAY>";
+
+	The structure of the XML file is:
+
+	<ul>
+		<li>(declaration)</li>
+		<li>(dtd stuff)</li>
+		<li>Element "PLAY"</li>
+		<ul>
+			<li>Element "TITLE"</li>
+			<ul>
+			    <li>Text "A Midsummer Night's Dream"</li>
+			</ul>
+		</ul>
+	</ul>
+
+	For this example, we want to print out the
+	title of the play. The text of the title (what
+	we want) is child of the "TITLE" element which
+	is a child of the "PLAY" element.
+
+	We want to skip the declaration and dtd, so the
+	method FirstChildElement() is a good choice. The
+	FirstChildElement() of the Document is the "PLAY"
+	Element, the FirstChildElement() of the "PLAY" Element
+	is the "TITLE" Element.
+
+	@until ( "TITLE" );
+
+	We can then use the convenience function GetText()
+	to get the title of the play.
+
+	@until title );
+
+	Text is just another Node in the XML DOM. And in
+	fact you should be a little cautious with it, as
+	text nodes can contain elements.
+
+	@verbatim
+	Consider: A Midsummer Night's <b>Dream</b>
+	@endverbatim
+
+	It is more correct to actually query the Text Node
+	if in doubt:
+
+	@until title );
+
+	Noting that here we use FirstChild() since we are
+	looking for XMLText, not an element, and ToText()
+	is a cast from a Node to a XMLText.
+*/
+
+
+bool example_4()
+{
+	static const char* xml =
+		"<information>"
+		"	<attributeApproach v='2' />"
+		"	<textApproach>"
+		"		<v>2</v>"
+		"	</textApproach>"
+		"</information>";
+
+	XMLDocument doc;
+	doc.Parse( xml );
+
+	int v0 = 0;
+	int v1 = 0;
+
+	XMLElement* attributeApproachElement = doc.FirstChildElement()->FirstChildElement( "attributeApproach" );
+	attributeApproachElement->QueryIntAttribute( "v", &v0 );
+
+	XMLElement* textApproachElement = doc.FirstChildElement()->FirstChildElement( "textApproach" );
+	textApproachElement->FirstChildElement( "v" )->QueryIntText( &v1 );
+
+	printf( "Both values are the same: %d and %d\n", v0, v1 );
+
+	return !doc.Error() && ( v0 == v1 );
+}
+/** @page Example_4 Read attributes and text information.
+	@dontinclude ./xmltest.cpp
+
+	There are fundamentally 2 ways of writing a key-value
+	pair into an XML file. (Something that's always annoyed
+	me about XML.) Either by using attributes, or by writing
+	the key name into an element and the value into
+	the text node wrapped by the element. Both approaches
+	are illustrated in this example, which shows two ways
+	to encode the value "2" into the key "v":
+
+	@skip example_4()
+	@until "</information>";
+
+	TinyXML-2 has accessors for both approaches.
+
+	When using an attribute, you navigate to the XMLElement
+	with that attribute and use the QueryIntAttribute()
+	group of methods. (Also QueryFloatAttribute(), etc.)
+
+	@skip XMLElement* attributeApproachElement
+	@until &v0 );
+
+	When using the text approach, you need to navigate
+	down one more step to the XMLElement that contains
+	the text. Note the extra FirstChildElement( "v" )
+	in the code below. The value of the text can then
+	be safely queried with the QueryIntText() group
+	of methods. (Also QueryFloatText(), etc.)
+
+	@skip XMLElement* textApproachElement
+	@until &v1 );
+*/
+
+
+int main( int argc, const char ** argv )
+{
+	#if defined( _MSC_VER ) && defined( TINYXML2_DEBUG )
+		_CrtMemCheckpoint( &startMemState );
+		// Enable MS Visual C++ debug heap memory leaks dump on exit
+		_CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) | _CRTDBG_LEAK_CHECK_DF);
+		{
+			int leaksOnStart = _CrtDumpMemoryLeaks();
+			XMLTest( "No leaks on start?", FALSE, leaksOnStart );
+		}
+	#endif
+
+	{
+		TIXMLASSERT( true );
+	}
+
+	if ( argc > 1 ) {
+		XMLDocument* doc = new XMLDocument();
+		clock_t startTime = clock();
+		doc->LoadFile( argv[1] );
+ 		clock_t loadTime = clock();
+		int errorID = doc->ErrorID();
+		delete doc; doc = 0;
+ 		clock_t deleteTime = clock();
+
+		printf( "Test file '%s' loaded. ErrorID=%d\n", argv[1], errorID );
+		if ( !errorID ) {
+			printf( "Load time=%u\n",   (unsigned)(loadTime - startTime) );
+			printf( "Delete time=%u\n", (unsigned)(deleteTime - loadTime) );
+			printf( "Total time=%u\n",  (unsigned)(deleteTime - startTime) );
+		}
+		exit(0);
+	}
+
+	FILE* fp = fopen( "resources/dream.xml", "r" );
+	if ( !fp ) {
+		printf( "Error opening test file 'dream.xml'.\n"
+				"Is your working directory the same as where \n"
+				"the xmltest.cpp and dream.xml file are?\n\n"
+	#if defined( _MSC_VER )
+				"In windows Visual Studio you may need to set\n"
+				"Properties->Debugging->Working Directory to '..'\n"
+	#endif
+			  );
+		exit( 1 );
+	}
+	fclose( fp );
+
+	XMLTest( "Example_1", 0, example_1() );
+	XMLTest( "Example_2", 0, example_2() );
+	XMLTest( "Example_3", 0, example_3() );
+	XMLTest( "Example_4", true, example_4() );
+
+	/* ------ Example 2: Lookup information. ---- */
+
+	{
+		static const char* test[] = {	"<element />",
+										"<element></element>",
+										"<element><subelement/></element>",
+										"<element><subelement></subelement></element>",
+										"<element><subelement><subsub/></subelement></element>",
+										"<!--comment beside elements--><element><subelement></subelement></element>",
+										"<!--comment beside elements, this time with spaces-->  \n <element>  <subelement> \n </subelement> </element>",
+										"<element attrib1='foo' attrib2=\"bar\" ></element>",
+										"<element attrib1='foo' attrib2=\"bar\" ><subelement attrib3='yeehaa' /></element>",
+										"<element>Text inside element.</element>",
+										"<element><b></b></element>",
+										"<element>Text inside and <b>bolded</b> in the element.</element>",
+										"<outer><element>Text inside and <b>bolded</b> in the element.</element></outer>",
+										"<element>This &amp; That.</element>",
+										"<element attrib='This&lt;That' />",
+										0
+		};
+		for( int i=0; test[i]; ++i ) {
+			XMLDocument doc;
+			doc.Parse( test[i] );
+			XMLTest( "Element test", false, doc.Error() );
+			doc.Print();
+			printf( "----------------------------------------------\n" );
+		}
+	}
+#if 1
+	{
+		static const char* test = "<!--hello world\n"
+								  "          line 2\r"
+								  "          line 3\r\n"
+								  "          line 4\n\r"
+								  "          line 5\r-->";
+
+		XMLDocument doc;
+		doc.Parse( test );
+		XMLTest( "Hello world declaration", false, doc.Error() );
+		doc.Print();
+	}
+
+	{
+		// This test is pre-test for the next one
+		// (where Element1 is inserted "after itself".
+		// This code didn't use to crash.
+		XMLDocument doc;
+		XMLElement* element1 = doc.NewElement("Element1");
+		XMLElement* element2 = doc.NewElement("Element2");
+		doc.InsertEndChild(element1);
+		doc.InsertEndChild(element2);
+		doc.InsertAfterChild(element2, element2);
+		doc.InsertAfterChild(element2, element2);
+	}
+
+	{
+		XMLDocument doc;
+		XMLElement* element1 = doc.NewElement("Element1");
+		XMLElement* element2 = doc.NewElement("Element2");
+		doc.InsertEndChild(element1);
+		doc.InsertEndChild(element2);
+
+		// This insertion "after itself"
+		// used to cause invalid memory access and crash
+		doc.InsertAfterChild(element1, element1);
+		doc.InsertAfterChild(element1, element1);
+		doc.InsertAfterChild(element2, element2);
+		doc.InsertAfterChild(element2, element2);
+	}
+
+	{
+		static const char* test = "<element>Text before.</element>";
+		XMLDocument doc;
+		doc.Parse( test );
+		XMLTest( "Element text before", false, doc.Error() );
+		XMLElement* root = doc.FirstChildElement();
+		XMLElement* newElement = doc.NewElement( "Subelement" );
+		root->InsertEndChild( newElement );
+		doc.Print();
+	}
+	{
+		XMLDocument* doc = new XMLDocument();
+		static const char* test = "<element><sub/></element>";
+		doc->Parse( test );
+		XMLTest( "Element with sub element", false, doc->Error() );
+		delete doc;
+	}
+	{
+		// Test: Programmatic DOM nodes insertion return values
+		XMLDocument doc;
+
+		XMLNode* first = doc.NewElement( "firstElement" );
+		XMLTest( "New element", true, first != 0 );
+		XMLNode* firstAfterInsertion = doc.InsertFirstChild( first );
+		XMLTest( "New element inserted first", true, firstAfterInsertion == first );
+
+		XMLNode* last = doc.NewElement( "lastElement" );
+		XMLTest( "New element", true, last != 0 );
+		XMLNode* lastAfterInsertion = doc.InsertEndChild( last );
+		XMLTest( "New element inserted last", true, lastAfterInsertion == last );
+
+		XMLNode* middle = doc.NewElement( "middleElement" );
+		XMLTest( "New element", true, middle != 0 );
+		XMLNode* middleAfterInsertion = doc.InsertAfterChild( first, middle );
+		XMLTest( "New element inserted middle", true, middleAfterInsertion == middle );
+	}
+	{
+		// Test: Programmatic DOM
+		// Build:
+		//		<element>
+		//			<!--comment-->
+		//			<sub attrib="0" />
+		//			<sub attrib="1" />
+		//			<sub attrib="2" >& Text!</sub>
+		//		<element>
+
+		XMLDocument* doc = new XMLDocument();
+		XMLNode* element = doc->InsertEndChild( doc->NewElement( "element" ) );
+
+		XMLElement* sub[3] = { doc->NewElement( "sub" ), doc->NewElement( "sub" ), doc->NewElement( "sub" ) };
+		for( int i=0; i<3; ++i ) {
+			sub[i]->SetAttribute( "attrib", i );
+		}
+		element->InsertEndChild( sub[2] );
+
+		const int dummyInitialValue = 1000;
+		int dummyValue = dummyInitialValue;
+
+		XMLNode* comment = element->InsertFirstChild( doc->NewComment( "comment" ) );
+		comment->SetUserData(&dummyValue);
+		element->InsertAfterChild( comment, sub[0] );
+		element->InsertAfterChild( sub[0], sub[1] );
+		sub[2]->InsertFirstChild( doc->NewText( "& Text!" ));
+		doc->Print();
+		XMLTest( "Programmatic DOM", "comment", doc->FirstChildElement( "element" )->FirstChild()->Value() );
+		XMLTest( "Programmatic DOM", "0", doc->FirstChildElement( "element" )->FirstChildElement()->Attribute( "attrib" ) );
+		XMLTest( "Programmatic DOM", 2, doc->FirstChildElement()->LastChildElement( "sub" )->IntAttribute( "attrib" ) );
+		XMLTest( "Programmatic DOM", "& Text!",
+				 doc->FirstChildElement()->LastChildElement( "sub" )->FirstChild()->ToText()->Value() );
+		XMLTest("User data - pointer", true, &dummyValue == comment->GetUserData(), false);
+		XMLTest("User data - value behind pointer", dummyInitialValue, dummyValue, false);
+
+		// And now deletion:
+		element->DeleteChild( sub[2] );
+		doc->DeleteNode( comment );
+
+		element->FirstChildElement()->SetAttribute( "attrib", true );
+		element->LastChildElement()->DeleteAttribute( "attrib" );
+
+		XMLTest( "Programmatic DOM", true, doc->FirstChildElement()->FirstChildElement()->BoolAttribute( "attrib" ) );
+		const int defaultIntValue = 10;
+		const int replacementIntValue = 20;
+		int value1 = defaultIntValue;
+		int value2 = doc->FirstChildElement()->LastChildElement()->IntAttribute( "attrib", replacementIntValue );
+		XMLError result = doc->FirstChildElement()->LastChildElement()->QueryIntAttribute( "attrib", &value1 );
+		XMLTest( "Programmatic DOM", XML_NO_ATTRIBUTE, result );
+		XMLTest( "Programmatic DOM", defaultIntValue, value1 );
+		XMLTest( "Programmatic DOM", replacementIntValue, value2 );
+
+		doc->Print();
+
+		{
+			XMLPrinter streamer;
+			doc->Print( &streamer );
+			printf( "%s", streamer.CStr() );
+		}
+		{
+			XMLPrinter streamer( 0, true );
+			doc->Print( &streamer );
+			XMLTest( "Compact mode", "<element><sub attrib=\"true\"/><sub/></element>", streamer.CStr(), false );
+		}
+		doc->SaveFile( "./resources/out/pretty.xml" );
+		XMLTest( "Save pretty.xml", false, doc->Error() );
+		doc->SaveFile( "./resources/out/compact.xml", true );
+		XMLTest( "Save compact.xml", false, doc->Error() );
+		delete doc;
+	}
+	{
+		// Test: Dream
+		// XML1 : 1,187,569 bytes	in 31,209 allocations
+		// XML2 :   469,073	bytes	in    323 allocations
+		//int newStart = gNew;
+		XMLDocument doc;
+		doc.LoadFile( "resources/dream.xml" );
+		XMLTest( "Load dream.xml", false, doc.Error() );
+
+		doc.SaveFile( "resources/out/dreamout.xml" );
+		XMLTest( "Save dreamout.xml", false, doc.Error() );
+		doc.PrintError();
+
+		XMLTest( "Dream", "xml version=\"1.0\"",
+						  doc.FirstChild()->ToDeclaration()->Value() );
+		XMLTest( "Dream", true, doc.FirstChild()->NextSibling()->ToUnknown() != 0 );
+		XMLTest( "Dream", "DOCTYPE PLAY SYSTEM \"play.dtd\"",
+						  doc.FirstChild()->NextSibling()->ToUnknown()->Value() );
+		XMLTest( "Dream", "And Robin shall restore amends.",
+						  doc.LastChild()->LastChild()->LastChild()->LastChild()->LastChildElement()->GetText() );
+		XMLTest( "Dream", "And Robin shall restore amends.",
+						  doc.LastChild()->LastChild()->LastChild()->LastChild()->LastChildElement()->GetText() );
+
+		XMLDocument doc2;
+		doc2.LoadFile( "resources/out/dreamout.xml" );
+		XMLTest( "Load dreamout.xml", false, doc2.Error() );
+		XMLTest( "Dream-out", "xml version=\"1.0\"",
+						  doc2.FirstChild()->ToDeclaration()->Value() );
+		XMLTest( "Dream-out", true, doc2.FirstChild()->NextSibling()->ToUnknown() != 0 );
+		XMLTest( "Dream-out", "DOCTYPE PLAY SYSTEM \"play.dtd\"",
+						  doc2.FirstChild()->NextSibling()->ToUnknown()->Value() );
+		XMLTest( "Dream-out", "And Robin shall restore amends.",
+						  doc2.LastChild()->LastChild()->LastChild()->LastChild()->LastChildElement()->GetText() );
+
+		//gNewTotal = gNew - newStart;
+	}
+
+
+	{
+		const char* error =	"<?xml version=\"1.0\" standalone=\"no\" ?>\n"
+							"<passages count=\"006\" formatversion=\"20020620\">\n"
+							"    <wrong error>\n"
+							"</passages>";
+
+		XMLDocument doc;
+		doc.Parse( error );
+		XMLTest( "Bad XML", XML_ERROR_PARSING_ATTRIBUTE, doc.ErrorID() );
+		const char* errorStr = doc.ErrorStr();
+		XMLTest("Formatted error string",
+			"Error=XML_ERROR_PARSING_ATTRIBUTE ErrorID=7 (0x7) Line number=3: XMLElement name=wrong",
+			errorStr);
+	}
+
+	{
+		const char* str = "<doc attr0='1' attr1='2.0' attr2='foo' />";
+
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLTest( "Top level attributes", false, doc.Error() );
+
+		XMLElement* ele = doc.FirstChildElement();
+
+		int iVal;
+		XMLError result;
+		double dVal;
+
+		result = ele->QueryDoubleAttribute( "attr0", &dVal );
+		XMLTest( "Query attribute: int as double", XML_SUCCESS, result);
+		XMLTest( "Query attribute: int as double", 1, (int)dVal );
+		XMLTest( "Query attribute: int as double", 1, (int)ele->DoubleAttribute("attr0"));
+
+		result = ele->QueryDoubleAttribute( "attr1", &dVal );
+		XMLTest( "Query attribute: double as double", XML_SUCCESS, result);
+		XMLTest( "Query attribute: double as double", 2.0, dVal );
+		XMLTest( "Query attribute: double as double", 2.0, ele->DoubleAttribute("attr1") );
+
+		result = ele->QueryIntAttribute( "attr1", &iVal );
+		XMLTest( "Query attribute: double as int", XML_SUCCESS, result);
+		XMLTest( "Query attribute: double as int", 2, iVal );
+
+		result = ele->QueryIntAttribute( "attr2", &iVal );
+		XMLTest( "Query attribute: not a number", XML_WRONG_ATTRIBUTE_TYPE, result );
+		XMLTest( "Query attribute: not a number", 4.0, ele->DoubleAttribute("attr2", 4.0) );
+
+		result = ele->QueryIntAttribute( "bar", &iVal );
+		XMLTest( "Query attribute: does not exist", XML_NO_ATTRIBUTE, result );
+		XMLTest( "Query attribute: does not exist", true, ele->BoolAttribute("bar", true) );
+	}
+
+	{
+		const char* str = "<doc/>";
+
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLTest( "Empty top element", false, doc.Error() );
+
+		XMLElement* ele = doc.FirstChildElement();
+
+		int iVal, iVal2;
+		double dVal, dVal2;
+
+		ele->SetAttribute( "str", "strValue" );
+		ele->SetAttribute( "int", 1 );
+		ele->SetAttribute( "double", -1.0 );
+
+		const char* answer = 0;
+		ele->QueryAttribute("str", &answer);
+		XMLTest("Query char attribute", "strValue", answer);
+
+		const char* cStr = ele->Attribute( "str" );
+		{
+			XMLError queryResult = ele->QueryIntAttribute( "int", &iVal );
+			XMLTest( "Query int attribute", XML_SUCCESS, queryResult);
+		}
+		{
+			XMLError queryResult = ele->QueryDoubleAttribute( "double", &dVal );
+			XMLTest( "Query double attribute", XML_SUCCESS, queryResult);
+		}
+
+		{
+			XMLError queryResult = ele->QueryAttribute( "int", &iVal2 );
+			XMLTest( "Query int attribute generic", (int)XML_SUCCESS, queryResult);
+		}
+		{
+			XMLError queryResult = ele->QueryAttribute( "double", &dVal2 );
+			XMLTest( "Query double attribute generic", (int)XML_SUCCESS, queryResult);
+		}
+
+		XMLTest( "Attribute match test", "strValue", ele->Attribute( "str", "strValue" ) );
+		XMLTest( "Attribute round trip. c-string.", "strValue", cStr );
+		XMLTest( "Attribute round trip. int.", 1, iVal );
+		XMLTest( "Attribute round trip. double.", -1, (int)dVal );
+		XMLTest( "Alternate query", true, iVal == iVal2 );
+		XMLTest( "Alternate query", true, dVal == dVal2 );
+		XMLTest( "Alternate query", true, iVal == ele->IntAttribute("int") );
+		XMLTest( "Alternate query", true, dVal == ele->DoubleAttribute("double") );
+	}
+
+	{
+		XMLDocument doc;
+		doc.LoadFile( "resources/utf8test.xml" );
+		XMLTest( "Load utf8test.xml", false, doc.Error() );
+
+		// Get the attribute "value" from the "Russian" element and check it.
+		XMLElement* element = doc.FirstChildElement( "document" )->FirstChildElement( "Russian" );
+		const unsigned char correctValue[] = {	0xd1U, 0x86U, 0xd0U, 0xb5U, 0xd0U, 0xbdU, 0xd0U, 0xbdU,
+												0xd0U, 0xbeU, 0xd1U, 0x81U, 0xd1U, 0x82U, 0xd1U, 0x8cU, 0 };
+
+		XMLTest( "UTF-8: Russian value.", (const char*)correctValue, element->Attribute( "value" ) );
+
+		const unsigned char russianElementName[] = {	0xd0U, 0xa0U, 0xd1U, 0x83U,
+														0xd1U, 0x81U, 0xd1U, 0x81U,
+														0xd0U, 0xbaU, 0xd0U, 0xb8U,
+														0xd0U, 0xb9U, 0 };
+		const char russianText[] = "<\xD0\xB8\xD0\xBC\xD0\xB5\xD0\xB5\xD1\x82>";
+
+		XMLText* text = doc.FirstChildElement( "document" )->FirstChildElement( (const char*) russianElementName )->FirstChild()->ToText();
+		XMLTest( "UTF-8: Browsing russian element name.",
+				 russianText,
+				 text->Value() );
+
+		// Now try for a round trip.
+		doc.SaveFile( "resources/out/utf8testout.xml" );
+		XMLTest( "UTF-8: Save testout.xml", false, doc.Error() );
+
+		// Check the round trip.
+		bool roundTripOkay = false;
+
+		FILE* saved  = fopen( "resources/out/utf8testout.xml", "r" );
+		XMLTest( "UTF-8: Open utf8testout.xml", true, saved != 0 );
+
+		FILE* verify = fopen( "resources/utf8testverify.xml", "r" );
+		XMLTest( "UTF-8: Open utf8testverify.xml", true, verify != 0 );
+
+		if ( saved && verify )
+		{
+			roundTripOkay = true;
+			char verifyBuf[256];
+			while ( fgets( verifyBuf, 256, verify ) )
+			{
+				char savedBuf[256];
+				fgets( savedBuf, 256, saved );
+				NullLineEndings( verifyBuf );
+				NullLineEndings( savedBuf );
+
+				if ( strcmp( verifyBuf, savedBuf ) )
+				{
+					printf( "verify:%s<\n", verifyBuf );
+					printf( "saved :%s<\n", savedBuf );
+					roundTripOkay = false;
+					break;
+				}
+			}
+		}
+		if ( saved )
+			fclose( saved );
+		if ( verify )
+			fclose( verify );
+		XMLTest( "UTF-8: Verified multi-language round trip.", true, roundTripOkay );
+	}
+
+	// --------GetText()-----------
+	{
+		const char* str = "<foo>This is  text</foo>";
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLTest( "Double whitespace", false, doc.Error() );
+		const XMLElement* element = doc.RootElement();
+
+		XMLTest( "GetText() normal use.", "This is  text", element->GetText() );
+
+		str = "<foo><b>This is text</b></foo>";
+		doc.Parse( str );
+		XMLTest( "Bold text simulation", false, doc.Error() );
+		element = doc.RootElement();
+
+		XMLTest( "GetText() contained element.", element->GetText() == 0, true );
+	}
+
+
+	// --------SetText()-----------
+	{
+		const char* str = "<foo></foo>";
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLTest( "Empty closed element", false, doc.Error() );
+		XMLElement* element = doc.RootElement();
+
+		element->SetText("darkness.");
+		XMLTest( "SetText() normal use (open/close).", "darkness.", element->GetText() );
+
+		element->SetText("blue flame.");
+		XMLTest( "SetText() replace.", "blue flame.", element->GetText() );
+
+		str = "<foo/>";
+		doc.Parse( str );
+		XMLTest( "Empty self-closed element", false, doc.Error() );
+		element = doc.RootElement();
+
+		element->SetText("The driver");
+		XMLTest( "SetText() normal use. (self-closing)", "The driver", element->GetText() );
+
+		element->SetText("<b>horses</b>");
+		XMLTest( "SetText() replace with tag-like text.", "<b>horses</b>", element->GetText() );
+		//doc.Print();
+
+		str = "<foo><bar>Text in nested element</bar></foo>";
+		doc.Parse( str );
+		XMLTest( "Text in nested element", false, doc.Error() );
+		element = doc.RootElement();
+
+		element->SetText("wolves");
+		XMLTest( "SetText() prefix to nested non-text children.", "wolves", element->GetText() );
+
+		str = "<foo/>";
+		doc.Parse( str );
+		XMLTest( "Empty self-closed element round 2", false, doc.Error() );
+		element = doc.RootElement();
+
+		element->SetText( "str" );
+		XMLTest( "SetText types", "str", element->GetText() );
+
+		element->SetText( 1 );
+		XMLTest( "SetText types", "1", element->GetText() );
+
+		element->SetText( 1U );
+		XMLTest( "SetText types", "1", element->GetText() );
+
+		element->SetText( true );
+		XMLTest( "SetText types", "true", element->GetText() );
+
+		element->SetText( 1.5f );
+		XMLTest( "SetText types", "1.5", element->GetText() );
+
+		element->SetText( 1.5 );
+		XMLTest( "SetText types", "1.5", element->GetText() );
+	}
+
+	// ---------- Attributes ---------
+	{
+		static const int64_t BIG = -123456789012345678;
+        static const uint64_t BIG_POS = 123456789012345678;
+		XMLDocument doc;
+		XMLElement* element = doc.NewElement("element");
+		doc.InsertFirstChild(element);
+
+		{
+			element->SetAttribute("attrib", int(-100));
+			{
+				int v = 0;
+				XMLError queryResult = element->QueryIntAttribute("attrib", &v);
+				XMLTest("Attribute: int", XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: int", -100, v, true);
+			}
+			{
+				int v = 0;
+				XMLError queryResult = element->QueryAttribute("attrib", &v);
+				XMLTest("Attribute: int", (int)XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: int", -100, v, true);
+			}
+			XMLTest("Attribute: int", -100, element->IntAttribute("attrib"), true);
+		}
+		{
+			element->SetAttribute("attrib", unsigned(100));
+			{
+				unsigned v = 0;
+				XMLError queryResult = element->QueryUnsignedAttribute("attrib", &v);
+				XMLTest("Attribute: unsigned", XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: unsigned", unsigned(100), v, true);
+			}
+			{
+				unsigned v = 0;
+				XMLError queryResult = element->QueryAttribute("attrib", &v);
+				XMLTest("Attribute: unsigned", (int)XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: unsigned", unsigned(100), v, true);
+			}
+			{
+				const char* v = "failed";
+				XMLError queryResult = element->QueryStringAttribute("not-attrib", &v);
+				XMLTest("Attribute: string default", false, queryResult == XML_SUCCESS);
+				queryResult = element->QueryStringAttribute("attrib", &v);
+				XMLTest("Attribute: string", XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: string", "100", v);
+			}
+			XMLTest("Attribute: unsigned", unsigned(100), element->UnsignedAttribute("attrib"), true);
+		}
+		{
+			element->SetAttribute("attrib", BIG);
+			{
+				int64_t v = 0;
+				XMLError queryResult = element->QueryInt64Attribute("attrib", &v);
+				XMLTest("Attribute: int64_t", XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: int64_t", BIG, v, true);
+			}
+			{
+				int64_t v = 0;
+				XMLError queryResult = element->QueryAttribute("attrib", &v);
+				XMLTest("Attribute: int64_t", (int)XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: int64_t", BIG, v, true);
+			}
+			XMLTest("Attribute: int64_t", BIG, element->Int64Attribute("attrib"), true);
+		}
+        {
+            element->SetAttribute("attrib", BIG_POS);
+            {
+                uint64_t v = 0;
+                XMLError queryResult = element->QueryUnsigned64Attribute("attrib", &v);
+                XMLTest("Attribute: uint64_t", XML_SUCCESS, queryResult, true);
+                XMLTest("Attribute: uint64_t", BIG_POS, v, true);
+            }
+            {
+                uint64_t v = 0;
+				XMLError queryResult = element->QueryAttribute("attrib", &v);
+                XMLTest("Attribute: uint64_t", (int)XML_SUCCESS, queryResult, true);
+                XMLTest("Attribute: uint64_t", BIG_POS, v, true);
+            }
+            XMLTest("Attribute: uint64_t", BIG_POS, element->Unsigned64Attribute("attrib"), true);
+        }
+        {
+			element->SetAttribute("attrib", true);
+			{
+				bool v = false;
+				XMLError queryResult = element->QueryBoolAttribute("attrib", &v);
+				XMLTest("Attribute: bool", XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: bool", true, v, true);
+			}
+			{
+				bool v = false;
+				XMLError queryResult = element->QueryAttribute("attrib", &v);
+				XMLTest("Attribute: bool", (int)XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: bool", true, v, true);
+			}
+			XMLTest("Attribute: bool", true, element->BoolAttribute("attrib"), true);
+		}
+		{
+			element->SetAttribute("attrib", true);
+			const char* result = element->Attribute("attrib");
+			XMLTest("Bool true is 'true'", "true", result);
+
+			XMLUtil::SetBoolSerialization("1", "0");
+			element->SetAttribute("attrib", true);
+			result = element->Attribute("attrib");
+			XMLTest("Bool true is '1'", "1", result);
+
+			XMLUtil::SetBoolSerialization(0, 0);
+		}
+		{
+			element->SetAttribute("attrib", 100.0);
+			{
+				double v = 0;
+				XMLError queryResult = element->QueryDoubleAttribute("attrib", &v);
+				XMLTest("Attribute: double", XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: double", 100.0, v, true);
+			}
+			{
+				double v = 0;
+				XMLError queryResult = element->QueryAttribute("attrib", &v);
+				XMLTest("Attribute: bool", (int)XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: double", 100.0, v, true);
+			}
+			XMLTest("Attribute: double", 100.0, element->DoubleAttribute("attrib"), true);
+		}
+		{
+			element->SetAttribute("attrib", 100.0f);
+			{
+				float v = 0;
+				XMLError queryResult = element->QueryFloatAttribute("attrib", &v);
+				XMLTest("Attribute: float", XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: float", 100.0f, v, true);
+			}
+			{
+				float v = 0;
+				XMLError queryResult = element->QueryAttribute("attrib", &v);
+				XMLTest("Attribute: float", (int)XML_SUCCESS, queryResult, true);
+				XMLTest("Attribute: float", 100.0f, v, true);
+			}
+			XMLTest("Attribute: float", 100.0f, element->FloatAttribute("attrib"), true);
+		}
+		{
+			element->SetText(BIG);
+			int64_t v = 0;
+			XMLError queryResult = element->QueryInt64Text(&v);
+			XMLTest("Element: int64_t", XML_SUCCESS, queryResult, true);
+			XMLTest("Element: int64_t", BIG, v, true);
+		}
+        {
+            element->SetText(BIG_POS);
+            uint64_t v = 0;
+            XMLError queryResult = element->QueryUnsigned64Text(&v);
+            XMLTest("Element: uint64_t", XML_SUCCESS, queryResult, true);
+            XMLTest("Element: uint64_t", BIG_POS, v, true);
+        }
+    }
+
+	// ---------- XMLPrinter stream mode ------
+	{
+		{
+			FILE* printerfp = fopen("resources/out/printer.xml", "w");
+			XMLTest("Open printer.xml", true, printerfp != 0);
+			XMLPrinter printer(printerfp);
+			printer.OpenElement("foo");
+			printer.PushAttribute("attrib-text", "text");
+			printer.PushAttribute("attrib-int", int(1));
+			printer.PushAttribute("attrib-unsigned", unsigned(2));
+			printer.PushAttribute("attrib-int64", int64_t(3));
+			printer.PushAttribute("attrib-uint64", uint64_t(37));
+			printer.PushAttribute("attrib-bool", true);
+			printer.PushAttribute("attrib-double", 4.0);
+			printer.CloseElement();
+			fclose(printerfp);
+		}
+		{
+			XMLDocument doc;
+			doc.LoadFile("resources/out/printer.xml");
+			XMLTest("XMLPrinter Stream mode: load", XML_SUCCESS, doc.ErrorID(), true);
+
+			const XMLDocument& cdoc = doc;
+
+			const XMLAttribute* attrib = cdoc.FirstChildElement("foo")->FindAttribute("attrib-text");
+			XMLTest("attrib-text", "text", attrib->Value(), true);
+			attrib = cdoc.FirstChildElement("foo")->FindAttribute("attrib-int");
+			XMLTest("attrib-int", int(1), attrib->IntValue(), true);
+			attrib = cdoc.FirstChildElement("foo")->FindAttribute("attrib-unsigned");
+			XMLTest("attrib-unsigned", unsigned(2), attrib->UnsignedValue(), true);
+			attrib = cdoc.FirstChildElement("foo")->FindAttribute("attrib-int64");
+			XMLTest("attrib-int64", int64_t(3), attrib->Int64Value(), true);
+			attrib = cdoc.FirstChildElement("foo")->FindAttribute("attrib-uint64");
+			XMLTest("attrib-uint64", uint64_t(37), attrib->Unsigned64Value(), true);
+			attrib = cdoc.FirstChildElement("foo")->FindAttribute("attrib-bool");
+			XMLTest("attrib-bool", true, attrib->BoolValue(), true);
+			attrib = cdoc.FirstChildElement("foo")->FindAttribute("attrib-double");
+			XMLTest("attrib-double", 4.0, attrib->DoubleValue(), true);
+		}
+		// Add API_testcatse :PushDeclaration();PushText();PushComment()
+		{
+			FILE* fp1 = fopen("resources/out/printer_1.xml", "w");
+			XMLPrinter printer(fp1);
+
+			printer.PushDeclaration("version = '1.0' encoding = 'utf-8'");
+
+			printer.OpenElement("foo");
+			printer.PushAttribute("attrib-text", "text");
+
+			printer.OpenElement("text");
+			printer.PushText("Tinyxml2");
+			printer.CloseElement();
+
+			printer.OpenElement("int");
+			printer.PushText(int(11));
+			printer.CloseElement();
+
+			printer.OpenElement("unsigned");
+			printer.PushText(unsigned(12));
+			printer.CloseElement();
+
+			printer.OpenElement("int64_t");
+			printer.PushText(int64_t(13));
+			printer.CloseElement();
+
+			printer.OpenElement("uint64_t");
+			printer.PushText(uint64_t(14));
+			printer.CloseElement();
+
+			printer.OpenElement("bool");
+			printer.PushText(true);
+			printer.CloseElement();
+
+			printer.OpenElement("float");
+			printer.PushText("1.56");
+			printer.CloseElement();
+
+			printer.OpenElement("double");
+			printer.PushText("12.12");
+			printer.CloseElement();
+
+			printer.OpenElement("comment");
+			printer.PushComment("this is Tinyxml2");
+			printer.CloseElement();
+
+			printer.CloseElement();
+			fclose(fp1);
+		}
+		{
+			XMLDocument doc;
+			doc.LoadFile("resources/out/printer_1.xml");
+			XMLTest("XMLPrinter Stream mode: load", XML_SUCCESS, doc.ErrorID(), true);
+
+			const XMLDocument& cdoc = doc;
+
+			const  XMLElement* root = cdoc.FirstChildElement("foo");
+
+			const char* text_value;
+			text_value = root->FirstChildElement("text")->GetText();
+			XMLTest("PushText( const char* text, bool cdata=false ) test", "Tinyxml2", text_value);
+
+			int  int_value;
+			int_value = root->FirstChildElement("int")->IntText();
+			XMLTest("PushText( int value ) test", 11, int_value);
+
+			unsigned  unsigned_value;
+			unsigned_value = root->FirstChildElement("unsigned")->UnsignedText();
+			XMLTest("PushText( unsigned value ) test", (unsigned)12, unsigned_value);
+
+			int64_t  int64_t_value;
+			int64_t_value = root->FirstChildElement("int64_t")->Int64Text();
+			XMLTest("PushText( int64_t value ) test", (int64_t) 13, int64_t_value);
+
+			uint64_t uint64_t_value;
+			uint64_t_value = root->FirstChildElement("uint64_t")->Unsigned64Text();
+			XMLTest("PushText( uint64_t value ) test", (uint64_t) 14, uint64_t_value);
+
+			float  float_value;
+			float_value = root->FirstChildElement("float")->FloatText();
+			XMLTest("PushText( float value ) test", 1.56f, float_value);
+
+			double double_value;
+			double_value = root->FirstChildElement("double")->DoubleText();
+			XMLTest("PushText( double value ) test", 12.12, double_value);
+
+			bool bool_value;
+			bool_value = root->FirstChildElement("bool")->BoolText();
+			XMLTest("PushText( bool value ) test", true, bool_value);
+
+			const XMLComment* comment = root->FirstChildElement("comment")->FirstChild()->ToComment();
+			const char* comment_value = comment->Value();
+			XMLTest("PushComment() test", "this is Tinyxml2", comment_value);
+
+			const XMLDeclaration* declaration = cdoc.FirstChild()->ToDeclaration();
+			const char* declaration_value = declaration->Value();
+			XMLTest("PushDeclaration() test", "version = '1.0' encoding = 'utf-8'", declaration_value);
+		}
+	}
+
+
+	// ---------- CDATA ---------------
+	{
+		const char* str =	"<xmlElement>"
+								"<![CDATA["
+									"I am > the rules!\n"
+									"...since I make symbolic puns"
+								"]]>"
+							"</xmlElement>";
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLTest( "CDATA symbolic puns round 1", false, doc.Error() );
+		doc.Print();
+
+		XMLTest( "CDATA parse.", "I am > the rules!\n...since I make symbolic puns",
+								 doc.FirstChildElement()->FirstChild()->Value(),
+								 false );
+	}
+
+	// ----------- CDATA -------------
+	{
+		const char* str =	"<xmlElement>"
+								"<![CDATA["
+									"<b>I am > the rules!</b>\n"
+									"...since I make symbolic puns"
+								"]]>"
+							"</xmlElement>";
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLTest( "CDATA symbolic puns round 2", false, doc.Error() );
+		doc.Print();
+
+		XMLTest( "CDATA parse. [ tixml1:1480107 ]",
+								 "<b>I am > the rules!</b>\n...since I make symbolic puns",
+								 doc.FirstChildElement()->FirstChild()->Value(),
+								 false );
+	}
+
+	// InsertAfterChild causes crash.
+	{
+		// InsertBeforeChild and InsertAfterChild causes crash.
+		XMLDocument doc;
+		XMLElement* parent = doc.NewElement( "Parent" );
+		doc.InsertFirstChild( parent );
+
+		XMLElement* childText0 = doc.NewElement( "childText0" );
+		XMLElement* childText1 = doc.NewElement( "childText1" );
+
+		XMLNode* childNode0 = parent->InsertEndChild( childText0 );
+		XMLTest( "InsertEndChild() return", true, childNode0 == childText0 );
+		XMLNode* childNode1 = parent->InsertAfterChild( childNode0, childText1 );
+		XMLTest( "InsertAfterChild() return", true, childNode1 == childText1 );
+
+		XMLTest( "Test InsertAfterChild on empty node. ", true, ( childNode1 == parent->LastChild() ) );
+	}
+
+	{
+		// Entities not being written correctly.
+		// From Lynn Allen
+
+		const char* passages =
+			"<?xml version=\"1.0\" standalone=\"no\" ?>"
+			"<passages count=\"006\" formatversion=\"20020620\">"
+				"<psg context=\"Line 5 has &quot;quotation marks&quot; and &apos;apostrophe marks&apos;."
+				" It also has &lt;, &gt;, and &amp;, as well as a fake copyright &#xA9;.\"> </psg>"
+			"</passages>";
+
+		XMLDocument doc;
+		doc.Parse( passages );
+		XMLTest( "Entity transformation parse round 1", false, doc.Error() );
+		XMLElement* psg = doc.RootElement()->FirstChildElement();
+		const char* context = psg->Attribute( "context" );
+		const char* expected = "Line 5 has \"quotation marks\" and 'apostrophe marks'. It also has <, >, and &, as well as a fake copyright \xC2\xA9.";
+
+		XMLTest( "Entity transformation: read. ", expected, context, true );
+
+		const char* textFilePath = "resources/out/textfile.txt";
+		FILE* textfile = fopen( textFilePath, "w" );
+		XMLTest( "Entity transformation: open text file for writing", true, textfile != 0, true );
+		if ( textfile )
+		{
+			XMLPrinter streamer( textfile );
+			bool acceptResult = psg->Accept( &streamer );
+			fclose( textfile );
+			XMLTest( "Entity transformation: Accept", true, acceptResult );
+		}
+
+		textfile = fopen( textFilePath, "r" );
+		XMLTest( "Entity transformation: open text file for reading", true, textfile != 0, true );
+		if ( textfile )
+		{
+			char buf[ 1024 ];
+			fgets( buf, 1024, textfile );
+			XMLTest( "Entity transformation: write. ",
+					 "<psg context=\"Line 5 has &quot;quotation marks&quot; and &apos;apostrophe marks&apos;."
+					 " It also has &lt;, &gt;, and &amp;, as well as a fake copyright \xC2\xA9.\"/>\n",
+					 buf, false );
+			fclose( textfile );
+		}
+	}
+
+	{
+		// Suppress entities.
+		const char* passages =
+			"<?xml version=\"1.0\" standalone=\"no\" ?>"
+			"<passages count=\"006\" formatversion=\"20020620\">"
+				"<psg context=\"Line 5 has &quot;quotation marks&quot; and &apos;apostrophe marks&apos;.\">Crazy &ttk;</psg>"
+			"</passages>";
+
+		XMLDocument doc( false );
+		doc.Parse( passages );
+		XMLTest( "Entity transformation parse round 2", false, doc.Error() );
+
+		XMLTest( "No entity parsing.",
+				 "Line 5 has &quot;quotation marks&quot; and &apos;apostrophe marks&apos;.",
+				 doc.FirstChildElement()->FirstChildElement()->Attribute( "context" ) );
+		XMLTest( "No entity parsing.", "Crazy &ttk;",
+				 doc.FirstChildElement()->FirstChildElement()->FirstChild()->Value() );
+		doc.Print();
+	}
+
+	{
+		const char* test = "<?xml version='1.0'?><a.elem xmi.version='2.0'/>";
+
+		XMLDocument doc;
+		doc.Parse( test );
+		XMLTest( "dot in names", false, doc.Error() );
+		XMLTest( "dot in names", "a.elem", doc.FirstChildElement()->Name() );
+		XMLTest( "dot in names", "2.0", doc.FirstChildElement()->Attribute( "xmi.version" ) );
+	}
+
+	{
+		const char* test = "<element><Name>1.1 Start easy ignore fin thickness&#xA;</Name></element>";
+
+		XMLDocument doc;
+		doc.Parse( test );
+		XMLTest( "fin thickness", false, doc.Error() );
+
+		XMLText* text = doc.FirstChildElement()->FirstChildElement()->FirstChild()->ToText();
+		XMLTest( "Entity with one digit.",
+				 "1.1 Start easy ignore fin thickness\n", text->Value(),
+				 false );
+	}
+
+	{
+		// DOCTYPE not preserved (950171)
+		//
+		const char* doctype =
+			"<?xml version=\"1.0\" ?>"
+			"<!DOCTYPE PLAY SYSTEM 'play.dtd'>"
+			"<!ELEMENT title (#PCDATA)>"
+			"<!ELEMENT books (title,authors)>"
+			"<element />";
+
+		XMLDocument doc;
+		doc.Parse( doctype );
+		XMLTest( "PLAY SYSTEM parse", false, doc.Error() );
+		doc.SaveFile( "resources/out/test7.xml" );
+		XMLTest( "PLAY SYSTEM save", false, doc.Error() );
+		doc.DeleteChild( doc.RootElement() );
+		doc.LoadFile( "resources/out/test7.xml" );
+		XMLTest( "PLAY SYSTEM load", false, doc.Error() );
+		doc.Print();
+
+		const XMLUnknown* decl = doc.FirstChild()->NextSibling()->ToUnknown();
+		XMLTest( "Correct value of unknown.", "DOCTYPE PLAY SYSTEM 'play.dtd'", decl->Value() );
+
+	}
+
+	{
+		// Comments do not stream out correctly.
+		const char* doctype =
+			"<!-- Somewhat<evil> -->";
+		XMLDocument doc;
+		doc.Parse( doctype );
+		XMLTest( "Comment somewhat evil", false, doc.Error() );
+
+		XMLComment* comment = doc.FirstChild()->ToComment();
+
+		XMLTest( "Comment formatting.", " Somewhat<evil> ", comment->Value() );
+	}
+	{
+		// Double attributes
+		const char* doctype = "<element attr='red' attr='blue' />";
+
+		XMLDocument doc;
+		doc.Parse( doctype );
+
+		XMLTest( "Parsing repeated attributes.", XML_ERROR_PARSING_ATTRIBUTE, doc.ErrorID() );	// is an  error to tinyxml (didn't use to be, but caused issues)
+		doc.PrintError();
+	}
+
+	{
+		// Embedded null in stream.
+		const char* doctype = "<element att\0r='red' attr='blue' />";
+
+		XMLDocument doc;
+		doc.Parse( doctype );
+		XMLTest( "Embedded null throws error.", true, doc.Error() );
+	}
+
+	{
+		// Empty documents should return TIXML_XML_ERROR_PARSING_EMPTY, bug 1070717
+		const char* str = "";
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLTest( "Empty document error", XML_ERROR_EMPTY_DOCUMENT, doc.ErrorID() );
+
+		// But be sure there is an error string!
+		const char* errorStr = doc.ErrorStr();
+		XMLTest("Error string should be set",
+			"Error=XML_ERROR_EMPTY_DOCUMENT ErrorID=13 (0xd) Line number=0",
+			errorStr);
+	}
+
+	{
+		// Documents with all whitespaces should return TIXML_XML_ERROR_PARSING_EMPTY, bug 1070717
+		const char* str = "    ";
+		XMLDocument doc;
+		doc.Parse( str );
+		XMLTest( "All whitespaces document error", XML_ERROR_EMPTY_DOCUMENT, doc.ErrorID() );
+	}
+
+	{
+		// Low entities
+		XMLDocument doc;
+		doc.Parse( "<test>&#x0e;</test>" );
+		XMLTest( "Hex values", false, doc.Error() );
+		const char result[] = { 0x0e, 0 };
+		XMLTest( "Low entities.", result, doc.FirstChildElement()->GetText() );
+		doc.Print();
+	}
+
+	{
+		// Attribute values with trailing quotes not handled correctly
+		XMLDocument doc;
+		doc.Parse( "<foo attribute=bar\" />" );
+		XMLTest( "Throw error with bad end quotes.", true, doc.Error() );
+	}
+
+	{
+		// [ 1663758 ] Failure to report error on bad XML
+		XMLDocument xml;
+		xml.Parse("<x>");
+		XMLTest("Missing end tag at end of input", true, xml.Error());
+		xml.Parse("<x> ");
+		XMLTest("Missing end tag with trailing whitespace", true, xml.Error());
+		xml.Parse("<x></y>");
+		XMLTest("Mismatched tags", XML_ERROR_MISMATCHED_ELEMENT, xml.ErrorID() );
+	}
+
+
+	{
+		// [ 1475201 ] TinyXML parses entities in comments
+		XMLDocument xml;
+		xml.Parse("<!-- declarations for <head> & <body> -->"
+				  "<!-- far &amp; away -->" );
+		XMLTest( "Declarations for head and body", false, xml.Error() );
+
+		XMLNode* e0 = xml.FirstChild();
+		XMLNode* e1 = e0->NextSibling();
+		XMLComment* c0 = e0->ToComment();
+		XMLComment* c1 = e1->ToComment();
+
+		XMLTest( "Comments ignore entities.", " declarations for <head> & <body> ", c0->Value(), true );
+		XMLTest( "Comments ignore entities.", " far &amp; away ", c1->Value(), true );
+	}
+
+	{
+		XMLDocument xml;
+		xml.Parse( "<Parent>"
+						"<child1 att=''/>"
+						"<!-- With this comment, child2 will not be parsed! -->"
+						"<child2 att=''/>"
+					"</Parent>" );
+		XMLTest( "Comments iteration", false, xml.Error() );
+		xml.Print();
+
+		int count = 0;
+
+		for( XMLNode* ele = xml.FirstChildElement( "Parent" )->FirstChild();
+			 ele;
+			 ele = ele->NextSibling() )
+		{
+			++count;
+		}
+
+		XMLTest( "Comments iterate correctly.", 3, count );
+	}
+
+	{
+		// trying to repro [1874301]. If it doesn't go into an infinite loop, all is well.
+		unsigned char buf[] = "<?xml version=\"1.0\" encoding=\"utf-8\"?><feed><![CDATA[Test XMLblablablalblbl";
+		buf[60] = 239;
+		buf[61] = 0;
+
+		XMLDocument doc;
+		doc.Parse( (const char*)buf);
+		XMLTest( "Broken CDATA", true, doc.Error() );
+	}
+
+
+	{
+		// bug 1827248 Error while parsing a little bit malformed file
+		// Actually not malformed - should work.
+		XMLDocument xml;
+		xml.Parse( "<attributelist> </attributelist >" );
+		XMLTest( "Handle end tag whitespace", false, xml.Error() );
+	}
+
+	{
+		// This one must not result in an infinite loop
+		XMLDocument xml;
+		xml.Parse( "<infinite>loop" );
+		XMLTest( "No closing element", true, xml.Error() );
+		XMLTest( "Infinite loop test.", true, true );
+	}
+#endif
+	{
+		const char* pub = "<?xml version='1.0'?> <element><sub/></element> <!--comment--> <!DOCTYPE>";
+		XMLDocument doc;
+		doc.Parse( pub );
+		XMLTest( "Trailing DOCTYPE", false, doc.Error() );
+
+		XMLDocument clone;
+		for( const XMLNode* node=doc.FirstChild(); node; node=node->NextSibling() ) {
+			XMLNode* copy = node->ShallowClone( &clone );
+			clone.InsertEndChild( copy );
+		}
+
+		clone.Print();
+
+		int count=0;
+		const XMLNode* a=clone.FirstChild();
+		const XMLNode* b=doc.FirstChild();
+		for( ; a && b; a=a->NextSibling(), b=b->NextSibling() ) {
+			++count;
+			XMLTest( "Clone and Equal", true, a->ShallowEqual( b ));
+		}
+		XMLTest( "Clone and Equal", 4, count );
+	}
+
+	{
+		// Deep Cloning of root element.
+		XMLDocument doc2;
+		XMLPrinter printer1;
+		{
+			// Make sure doc1 is deleted before we test doc2
+			const char* xml =
+				"<root>"
+				"    <child1 foo='bar'/>"
+				"    <!-- comment thing -->"
+				"    <child2 val='1'>Text</child2>"
+				"</root>";
+			XMLDocument doc;
+			doc.Parse(xml);
+			XMLTest( "Parse before deep cloning root element", false, doc.Error() );
+
+			doc.Print(&printer1);
+			XMLNode* root = doc.RootElement()->DeepClone(&doc2);
+			doc2.InsertFirstChild(root);
+		}
+		XMLPrinter printer2;
+		doc2.Print(&printer2);
+
+		XMLTest("Deep clone of element.", printer1.CStr(), printer2.CStr(), true);
+	}
+
+	{
+		// Deep Cloning of sub element.
+		XMLDocument doc2;
+		XMLPrinter printer1;
+		{
+			// Make sure doc1 is deleted before we test doc2
+			const char* xml =
+				"<?xml version ='1.0'?>"
+				"<root>"
+				"    <child1 foo='bar'/>"
+				"    <!-- comment thing -->"
+				"    <child2 val='1'>Text</child2>"
+				"</root>";
+			XMLDocument doc;
+			doc.Parse(xml);
+			XMLTest( "Parse before deep cloning sub element", false, doc.Error() );
+
+			const XMLElement* subElement = doc.FirstChildElement("root")->FirstChildElement("child2");
+			bool acceptResult = subElement->Accept(&printer1);
+			XMLTest( "Accept before deep cloning", true, acceptResult );
+
+			XMLNode* clonedSubElement = subElement->DeepClone(&doc2);
+			doc2.InsertFirstChild(clonedSubElement);
+		}
+		XMLPrinter printer2;
+		doc2.Print(&printer2);
+
+		XMLTest("Deep clone of sub-element.", printer1.CStr(), printer2.CStr(), true);
+	}
+
+	{
+		// Deep cloning of document.
+		XMLDocument doc2;
+		XMLPrinter printer1;
+		{
+			// Make sure doc1 is deleted before we test doc2
+			const char* xml =
+				"<?xml version ='1.0'?>"
+				"<!-- Top level comment. -->"
+				"<root>"
+				"    <child1 foo='bar'/>"
+				"    <!-- comment thing -->"
+				"    <child2 val='1'>Text</child2>"
+				"</root>";
+			XMLDocument doc;
+			doc.Parse(xml);
+			XMLTest( "Parse before deep cloning document", false, doc.Error() );
+			doc.Print(&printer1);
+
+			doc.DeepCopy(&doc2);
+		}
+		XMLPrinter printer2;
+		doc2.Print(&printer2);
+
+		XMLTest("DeepCopy of document.", printer1.CStr(), printer2.CStr(), true);
+	}
+
+
+ 	{
+		// This shouldn't crash.
+		XMLDocument doc;
+		if(XML_SUCCESS != doc.LoadFile( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ))
+		{
+			doc.PrintError();
+		}
+		XMLTest( "Error in snprinf handling.", true, doc.Error() );
+	}
+
+	{
+		// Attribute ordering.
+		static const char* xml = "<element attrib1=\"1\" attrib2=\"2\" attrib3=\"3\" />";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Parse for attribute ordering", false, doc.Error() );
+		XMLElement* ele = doc.FirstChildElement();
+
+		const XMLAttribute* a = ele->FirstAttribute();
+		XMLTest( "Attribute order", "1", a->Value() );
+		a = a->Next();
+		XMLTest( "Attribute order", "2", a->Value() );
+		a = a->Next();
+		XMLTest( "Attribute order", "3", a->Value() );
+		XMLTest( "Attribute order", "attrib3", a->Name() );
+
+		ele->DeleteAttribute( "attrib2" );
+		a = ele->FirstAttribute();
+		XMLTest( "Attribute order", "1", a->Value() );
+		a = a->Next();
+		XMLTest( "Attribute order", "3", a->Value() );
+
+		ele->DeleteAttribute( "attrib1" );
+		ele->DeleteAttribute( "attrib3" );
+		XMLTest( "Attribute order (empty)", true, ele->FirstAttribute() == 0 );
+	}
+
+	{
+		// Make sure an attribute with a space in it succeeds.
+		static const char* xml0 = "<element attribute1= \"Test Attribute\"/>";
+		static const char* xml1 = "<element attribute1 =\"Test Attribute\"/>";
+		static const char* xml2 = "<element attribute1 = \"Test Attribute\"/>";
+		XMLDocument doc0;
+		doc0.Parse( xml0 );
+		XMLTest( "Parse attribute with space 1", false, doc0.Error() );
+		XMLDocument doc1;
+		doc1.Parse( xml1 );
+		XMLTest( "Parse attribute with space 2", false, doc1.Error() );
+		XMLDocument doc2;
+		doc2.Parse( xml2 );
+		XMLTest( "Parse attribute with space 3", false, doc2.Error() );
+
+		XMLElement* ele = 0;
+		ele = doc0.FirstChildElement();
+		XMLTest( "Attribute with space #1", "Test Attribute", ele->Attribute( "attribute1" ) );
+		ele = doc1.FirstChildElement();
+		XMLTest( "Attribute with space #2", "Test Attribute", ele->Attribute( "attribute1" ) );
+		ele = doc2.FirstChildElement();
+		XMLTest( "Attribute with space #3", "Test Attribute", ele->Attribute( "attribute1" ) );
+	}
+
+	{
+		// Make sure we don't go into an infinite loop.
+		static const char* xml = "<doc><element attribute='attribute'/><element attribute='attribute'/></doc>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Parse two elements with attribute", false, doc.Error() );
+		XMLElement* ele0 = doc.FirstChildElement()->FirstChildElement();
+		XMLElement* ele1 = ele0->NextSiblingElement();
+		bool equal = ele0->ShallowEqual( ele1 );
+
+		XMLTest( "Infinite loop in shallow equal.", true, equal );
+	}
+
+	// -------- Handles ------------
+	{
+		static const char* xml = "<element attrib='bar'><sub>Text</sub></element>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Handle, parse element with attribute and nested element", false, doc.Error() );
+
+		{
+			XMLElement* ele = XMLHandle( doc ).FirstChildElement( "element" ).FirstChild().ToElement();
+			XMLTest( "Handle, non-const, element is found", true, ele != 0 );
+			XMLTest( "Handle, non-const, element name matches", "sub", ele->Value() );
+		}
+
+		{
+			XMLHandle docH( doc );
+			XMLElement* ele = docH.FirstChildElement( "noSuchElement" ).FirstChildElement( "element" ).ToElement();
+			XMLTest( "Handle, non-const, element not found", true, ele == 0 );
+		}
+
+		{
+			const XMLElement* ele = XMLConstHandle( doc ).FirstChildElement( "element" ).FirstChild().ToElement();
+			XMLTest( "Handle, const, element is found", true, ele != 0 );
+			XMLTest( "Handle, const, element name matches", "sub", ele->Value() );
+		}
+
+		{
+			XMLConstHandle docH( doc );
+			const XMLElement* ele = docH.FirstChildElement( "noSuchElement" ).FirstChildElement( "element" ).ToElement();
+			XMLTest( "Handle, const, element not found", true, ele == 0 );
+		}
+	}
+	{
+		// Default Declaration & BOM
+		XMLDocument doc;
+		doc.InsertEndChild( doc.NewDeclaration() );
+		doc.SetBOM( true );
+
+		XMLPrinter printer;
+		doc.Print( &printer );
+
+		static const char* result  = "\xef\xbb\xbf<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+		XMLTest( "BOM and default declaration", result, printer.CStr(), false );
+		XMLTest( "CStrSize", true, printer.CStrSize() == 42, false );
+	}
+	{
+		const char* xml = "<ipxml ws='1'><info bla=' /></ipxml>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Ill formed XML", true, doc.Error() );
+	}
+
+    {
+        //API:IntText(),UnsignedText(),Int64Text(),DoubleText(),BoolText() and FloatText() test
+        const char* xml = "<point> <IntText>-24</IntText> <UnsignedText>42</UnsignedText> \
+						   <Int64Text>38</Int64Text> <BoolText>true</BoolText> <DoubleText>2.35</DoubleText> </point>";
+        XMLDocument doc;
+        doc.Parse(xml);
+
+        const XMLElement* pointElement = doc.RootElement();
+        int test1 = pointElement->FirstChildElement("IntText")->IntText();
+        XMLTest("IntText() test", -24, test1);
+
+        unsigned test2 = pointElement->FirstChildElement("UnsignedText")->UnsignedText();
+        XMLTest("UnsignedText() test", static_cast<unsigned>(42), test2);
+
+        int64_t test3 = pointElement->FirstChildElement("Int64Text")->Int64Text();
+        XMLTest("Int64Text() test", static_cast<int64_t>(38), test3);
+
+        double test4 = pointElement->FirstChildElement("DoubleText")->DoubleText();
+        XMLTest("DoubleText() test", 2.35, test4);
+
+        float test5 = pointElement->FirstChildElement("DoubleText")->FloatText();
+        XMLTest("FloatText()) test", 2.35f, test5);
+
+        bool test6 = pointElement->FirstChildElement("BoolText")->BoolText();
+        XMLTest("FloatText()) test", true, test6);
+    }
+
+    {
+        // hex value test
+        const char* xml = "<point> <IntText>  0x2020</IntText> <UnsignedText>0X2020</UnsignedText> \
+						   <Int64Text> 0x1234</Int64Text></point>";
+        XMLDocument doc;
+        doc.Parse(xml);
+
+        const XMLElement* pointElement = doc.RootElement();
+        int test1 = pointElement->FirstChildElement("IntText")->IntText();
+        XMLTest("IntText() hex value test", 0x2020, test1);
+
+        unsigned test2 = pointElement->FirstChildElement("UnsignedText")->UnsignedText();
+        XMLTest("UnsignedText() hex value test", static_cast<unsigned>(0x2020), test2);
+
+        int64_t test3 = pointElement->FirstChildElement("Int64Text")->Int64Text();
+        XMLTest("Int64Text() hex value test", static_cast<int64_t>(0x1234), test3);
+    }
+
+	{
+		//API:ShallowEqual() test
+		const char* xml = "<playlist id = 'playlist'>"
+						    "<property name = 'track_name'>voice</property>"
+						  "</playlist>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		const XMLNode* PlaylistNode = doc.RootElement();
+		const XMLNode* PropertyNode = PlaylistNode->FirstChildElement();
+		bool result;
+		result = PlaylistNode->ShallowEqual(PropertyNode);
+		XMLTest("ShallowEqual() test",false,result);
+		result = PlaylistNode->ShallowEqual(PlaylistNode);
+		XMLTest("ShallowEqual() test",true,result);
+	}
+
+	{
+		//API: previousSiblingElement() and NextSiblingElement() test
+		const char* xml = "<playlist id = 'playlist'>"
+						    "<property name = 'track_name'>voice</property>"
+						    "<entry out = '946' producer = '2_playlist1' in = '0'/>"
+							"<blank length = '1'/>"
+						  "</playlist>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLElement* ElementPlaylist = doc.FirstChildElement("playlist");
+		XMLTest("previousSiblingElement() test",true,ElementPlaylist != 0);
+		const XMLElement* pre = ElementPlaylist->PreviousSiblingElement();
+		XMLTest("previousSiblingElement() test",true,pre == 0);
+		const XMLElement* ElementBlank = ElementPlaylist->FirstChildElement("entry")->NextSiblingElement("blank");
+		XMLTest("NextSiblingElement() test",true,ElementBlank != 0);
+		const XMLElement* next = ElementBlank->NextSiblingElement();
+		XMLTest("NextSiblingElement() test",true,next == 0);
+		const XMLElement* ElementEntry = ElementBlank->PreviousSiblingElement("entry");
+		XMLTest("PreviousSiblingElement test",true,ElementEntry != 0);
+	}
+
+	// QueryXYZText
+	{
+		const char* xml = "<point> <x>1.2</x> <y>1</y> <z>38</z> <valid>true</valid> </point>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Parse points", false, doc.Error() );
+
+		const XMLElement* pointElement = doc.RootElement();
+
+		{
+			int intValue = 0;
+			XMLError queryResult = pointElement->FirstChildElement( "y" )->QueryIntText( &intValue );
+			XMLTest( "QueryIntText result", XML_SUCCESS, queryResult, false );
+			XMLTest( "QueryIntText", 1, intValue, false );
+		}
+
+		{
+			unsigned unsignedValue = 0;
+			XMLError queryResult = pointElement->FirstChildElement( "y" )->QueryUnsignedText( &unsignedValue );
+			XMLTest( "QueryUnsignedText result", XML_SUCCESS, queryResult, false );
+			XMLTest( "QueryUnsignedText", (unsigned)1, unsignedValue, false );
+		}
+
+		{
+			float floatValue = 0;
+			XMLError queryResult = pointElement->FirstChildElement( "x" )->QueryFloatText( &floatValue );
+			XMLTest( "QueryFloatText result", XML_SUCCESS, queryResult, false );
+			XMLTest( "QueryFloatText", 1.2f, floatValue, false );
+		}
+
+		{
+			double doubleValue = 0;
+			XMLError queryResult = pointElement->FirstChildElement( "x" )->QueryDoubleText( &doubleValue );
+			XMLTest( "QueryDoubleText result", XML_SUCCESS, queryResult, false );
+			XMLTest( "QueryDoubleText", 1.2, doubleValue, false );
+		}
+
+		{
+			bool boolValue = false;
+			XMLError queryResult = pointElement->FirstChildElement( "valid" )->QueryBoolText( &boolValue );
+			XMLTest( "QueryBoolText result", XML_SUCCESS, queryResult, false );
+			XMLTest( "QueryBoolText", true, boolValue, false );
+		}
+	}
+
+	{
+		const char* xml = "<element><_sub/><:sub/><sub:sub/><sub-sub/></element>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Non-alpha element lead letter parses.", false, doc.Error() );
+	}
+
+    {
+        const char* xml = "<element _attr1=\"foo\" :attr2=\"bar\"></element>";
+        XMLDocument doc;
+        doc.Parse( xml );
+        XMLTest("Non-alpha attribute lead character parses.", false, doc.Error());
+    }
+
+    {
+        const char* xml = "<3lement></3lement>";
+        XMLDocument doc;
+        doc.Parse( xml );
+        XMLTest("Element names with lead digit fail to parse.", true, doc.Error());
+    }
+
+	{
+		const char* xml = "<element/>WOA THIS ISN'T GOING TO PARSE";
+		XMLDocument doc;
+		doc.Parse( xml, 10 );
+		XMLTest( "Set length of incoming data", false, doc.Error() );
+	}
+
+    {
+        XMLDocument doc;
+        XMLTest( "Document is initially empty", true, doc.NoChildren() );
+        doc.Clear();
+        XMLTest( "Empty is empty after Clear()", true, doc.NoChildren() );
+        doc.LoadFile( "resources/dream.xml" );
+        XMLTest( "Load dream.xml", false, doc.Error() );
+        XMLTest( "Document has something to Clear()", false, doc.NoChildren() );
+        doc.Clear();
+        XMLTest( "Document Clear()'s", true, doc.NoChildren() );
+    }
+
+    {
+        XMLDocument doc;
+        XMLTest( "No error initially", false, doc.Error() );
+        XMLError error = doc.Parse( "This is not XML" );
+        XMLTest( "Error after invalid XML", true, doc.Error() );
+        XMLTest( "Error after invalid XML", error, doc.ErrorID() );
+        doc.Clear();
+        XMLTest( "No error after Clear()", false, doc.Error() );
+    }
+
+	// ----------- Whitespace ------------
+	{
+		const char* xml = "<element>"
+							"<a> This \nis &apos;  text  &apos; </a>"
+							"<b>  This is &apos; text &apos;  \n</b>"
+							"<c>This  is  &apos;  \n\n text &apos;</c>"
+						  "</element>";
+		XMLDocument doc( true, COLLAPSE_WHITESPACE );
+		doc.Parse( xml );
+		XMLTest( "Parse with whitespace collapsing and &apos", false, doc.Error() );
+
+		const XMLElement* element = doc.FirstChildElement();
+		for( const XMLElement* parent = element->FirstChildElement();
+			 parent;
+			 parent = parent->NextSiblingElement() )
+		{
+			XMLTest( "Whitespace collapse", "This is ' text '", parent->GetText() );
+		}
+	}
+
+#if 0
+	{
+		// Passes if assert doesn't fire.
+		XMLDocument xmlDoc;
+
+	    xmlDoc.NewDeclaration();
+	    xmlDoc.NewComment("Configuration file");
+
+	    XMLElement *root = xmlDoc.NewElement("settings");
+	    root->SetAttribute("version", 2);
+	}
+#endif
+
+	{
+		const char* xml = "<element>    </element>";
+		XMLDocument doc( true, COLLAPSE_WHITESPACE );
+		doc.Parse( xml );
+		XMLTest( "Parse with all whitespaces", false, doc.Error() );
+		XMLTest( "Whitespace  all space", true, 0 == doc.FirstChildElement()->FirstChild() );
+	}
+
+	// ----------- Preserve Whitespace ------------
+	{
+		const char* xml = "<element>This  is  &apos;  \n\n text &apos;</element>";
+		XMLDocument doc(true, PRESERVE_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with whitespace preserved", false, doc.Error());
+		XMLTest("Whitespace preserved", "This  is  '  \n\n text '", doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element> This \nis &apos;  text  &apos;  </element>";
+		XMLDocument doc(true, PRESERVE_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with whitespace preserved", false, doc.Error());
+		XMLTest("Whitespace preserved", " This \nis '  text  '  ", doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element>  \n This is &apos; text &apos;  \n</element>";
+		XMLDocument doc(true, PRESERVE_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with whitespace preserved", false, doc.Error());
+		XMLTest("Whitespace preserved", "  \n This is ' text '  \n", doc.FirstChildElement()->GetText());
+	}
+
+	// Following cases are for text that is all whitespace which are not preserved intentionally
+	{
+		const char* xml = "<element> </element>";
+		XMLDocument doc(true, PRESERVE_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with whitespace preserved", false, doc.Error());
+		XMLTest("Whitespace preserved", true, 0 == doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element>   </element>";
+		XMLDocument doc(true, PRESERVE_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with whitespace preserved", false, doc.Error());
+		XMLTest("Whitespace preserved", true, 0 == doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element>\n\n</element>";
+		XMLDocument doc(true, PRESERVE_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with whitespace preserved", false, doc.Error());
+		XMLTest("Whitespace preserved", true, 0 == doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element>  \n</element>";
+		XMLDocument doc(true, PRESERVE_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with whitespace preserved", false, doc.Error());
+		XMLTest("Whitespace preserved", true, 0 == doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element> \n \n </element>";
+		XMLDocument doc(true, PRESERVE_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with whitespace preserved", false, doc.Error());
+		XMLTest("Whitespace preserved", true, 0 == doc.FirstChildElement()->GetText());
+	}
+
+	// ----------- Pedantic Whitespace ------------
+	{
+		const char* xml = "<element>This  is  &apos;  \n\n text &apos;</element>";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", "This  is  '  \n\n text '", doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element> This \nis &apos;  text  &apos;  </element>";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", " This \nis '  text  '  ", doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element>  \n This is &apos; text &apos;  \n</element>";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", "  \n This is ' text '  \n", doc.FirstChildElement()->GetText());
+	}
+
+	// Following cases are for text that is all whitespace which is preserved with pedantic mode
+	{
+		const char* xml = "<element> </element>";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", " ", doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element>   </element>";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", "   ", doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element>\n\n</element>\n";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", "\n\n", doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element>  \n</element> \n ";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", "  \n", doc.FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element> \n  \n </element>  ";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", " \n  \n ", doc.FirstChildElement()->GetText());
+	}
+
+	// Following cases are for checking nested elements are still parsed with pedantic whitespace
+	{
+		const char* xml = "<element>\n\t<a> This is nested text </a>\n</element>  ";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse nested elements with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", " This is nested text ", doc.RootElement()->FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element>  <b> </b>  </element>\n";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse nested elements with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", " ", doc.RootElement()->FirstChildElement()->GetText());
+	}
+
+	{
+		const char* xml = "<element>  <c attribute=\"test\"/>  </element>\n ";
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.Parse(xml);
+		XMLTest("Parse nested elements with pedantic whitespace", false, doc.Error());
+		XMLTest("Pedantic whitespace", true, 0 == doc.RootElement()->FirstChildElement()->GetText());
+	}
+
+	// Check sample xml can be parsed with pedantic mode
+	{
+		XMLDocument doc(true, PEDANTIC_WHITESPACE);
+		doc.LoadFile("resources/dream.xml");
+		XMLTest("Load dream.xml with pedantic whitespace mode", false, doc.Error());
+
+		XMLTest("Dream", "xml version=\"1.0\"",
+			doc.FirstChild()->ToDeclaration()->Value());
+		XMLTest("Dream", true, doc.FirstChild()->NextSibling()->ToUnknown() != 0);
+		XMLTest("Dream", "DOCTYPE PLAY SYSTEM \"play.dtd\"",
+			doc.FirstChild()->NextSibling()->ToUnknown()->Value());
+		XMLTest("Dream", "And Robin shall restore amends.",
+			doc.LastChild()->LastChild()->LastChild()->LastChild()->LastChildElement()->GetText());
+	}
+
+	{
+		// An assert should not fire.
+		const char* xml = "<element/>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Parse with self-closed element", false, doc.Error() );
+		XMLElement* ele = doc.NewElement( "unused" );		// This will get cleaned up with the 'doc' going out of scope.
+		XMLTest( "Tracking unused elements", true, ele != 0, false );
+	}
+
+
+	{
+		const char* xml = "<parent><child>abc</child></parent>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Parse for printing of sub-element", false, doc.Error() );
+		XMLElement* ele = doc.FirstChildElement( "parent")->FirstChildElement( "child");
+
+		XMLPrinter printer;
+		bool acceptResult = ele->Accept( &printer );
+		XMLTest( "Accept of sub-element", true, acceptResult );
+		XMLTest( "Printing of sub-element", "<child>abc</child>\n", printer.CStr(), false );
+	}
+
+
+	{
+		XMLDocument doc;
+		XMLError error = doc.LoadFile( "resources/empty.xml" );
+		XMLTest( "Loading an empty file", XML_ERROR_EMPTY_DOCUMENT, error );
+		XMLTest( "Loading an empty file and ErrorName as string", "XML_ERROR_EMPTY_DOCUMENT", doc.ErrorName() );
+		doc.PrintError();
+	}
+
+	{
+        // BOM preservation
+        static const char* xml_bom_preservation  = "\xef\xbb\xbf<element/>\n";
+        {
+			XMLDocument doc;
+			XMLTest( "BOM preservation (parse)", XML_SUCCESS, doc.Parse( xml_bom_preservation ), false );
+            XMLPrinter printer;
+            doc.Print( &printer );
+
+            XMLTest( "BOM preservation (compare)", xml_bom_preservation, printer.CStr(), false, true );
+			doc.SaveFile( "resources/out/bomtest.xml" );
+			XMLTest( "Save bomtest.xml", false, doc.Error() );
+        }
+		{
+			XMLDocument doc;
+			doc.LoadFile( "resources/out/bomtest.xml" );
+			XMLTest( "Load bomtest.xml", false, doc.Error() );
+			XMLTest( "BOM preservation (load)", true, doc.HasBOM(), false );
+
+            XMLPrinter printer;
+            doc.Print( &printer );
+            XMLTest( "BOM preservation (compare)", xml_bom_preservation, printer.CStr(), false, true );
+		}
+	}
+
+	{
+		// Insertion with Removal
+		const char* xml = "<?xml version=\"1.0\" ?>"
+			"<root>"
+			"<one>"
+			"<subtree>"
+			"<elem>element 1</elem>text<!-- comment -->"
+			"</subtree>"
+			"</one>"
+			"<two/>"
+			"</root>";
+		const char* xmlInsideTwo = "<?xml version=\"1.0\" ?>"
+			"<root>"
+			"<one/>"
+			"<two>"
+			"<subtree>"
+			"<elem>element 1</elem>text<!-- comment -->"
+			"</subtree>"
+			"</two>"
+			"</root>";
+		const char* xmlAfterOne = "<?xml version=\"1.0\" ?>"
+			"<root>"
+			"<one/>"
+			"<subtree>"
+			"<elem>element 1</elem>text<!-- comment -->"
+			"</subtree>"
+			"<two/>"
+			"</root>";
+		const char* xmlAfterTwo = "<?xml version=\"1.0\" ?>"
+			"<root>"
+			"<one/>"
+			"<two/>"
+			"<subtree>"
+			"<elem>element 1</elem>text<!-- comment -->"
+			"</subtree>"
+			"</root>";
+
+		XMLDocument doc;
+		doc.Parse(xml);
+		XMLTest( "Insertion with removal parse round 1", false, doc.Error() );
+		XMLElement* subtree = doc.RootElement()->FirstChildElement("one")->FirstChildElement("subtree");
+		XMLElement* two = doc.RootElement()->FirstChildElement("two");
+		two->InsertFirstChild(subtree);
+		XMLPrinter printer1(0, true);
+		bool acceptResult = doc.Accept(&printer1);
+		XMLTest("Move node from within <one> to <two> - Accept()", true, acceptResult);
+		XMLTest("Move node from within <one> to <two>", xmlInsideTwo, printer1.CStr());
+
+		doc.Parse(xml);
+		XMLTest( "Insertion with removal parse round 2", false, doc.Error() );
+		subtree = doc.RootElement()->FirstChildElement("one")->FirstChildElement("subtree");
+		two = doc.RootElement()->FirstChildElement("two");
+		doc.RootElement()->InsertAfterChild(two, subtree);
+		XMLPrinter printer2(0, true);
+		acceptResult = doc.Accept(&printer2);
+		XMLTest("Move node from within <one> after <two> - Accept()", true, acceptResult);
+		XMLTest("Move node from within <one> after <two>", xmlAfterTwo, printer2.CStr(), false);
+
+		doc.Parse(xml);
+		XMLTest( "Insertion with removal parse round 3", false, doc.Error() );
+		XMLNode* one = doc.RootElement()->FirstChildElement("one");
+		subtree = one->FirstChildElement("subtree");
+		doc.RootElement()->InsertAfterChild(one, subtree);
+		XMLPrinter printer3(0, true);
+		acceptResult = doc.Accept(&printer3);
+		XMLTest("Move node from within <one> after <one> - Accept()", true, acceptResult);
+		XMLTest("Move node from within <one> after <one>", xmlAfterOne, printer3.CStr(), false);
+
+		doc.Parse(xml);
+		XMLTest( "Insertion with removal parse round 4", false, doc.Error() );
+		subtree = doc.RootElement()->FirstChildElement("one")->FirstChildElement("subtree");
+		two = doc.RootElement()->FirstChildElement("two");
+		XMLTest("<two> is the last child at root level", true, two == doc.RootElement()->LastChildElement());
+		doc.RootElement()->InsertEndChild(subtree);
+		XMLPrinter printer4(0, true);
+		acceptResult = doc.Accept(&printer4);
+		XMLTest("Move node from within <one> after <two> - Accept()", true, acceptResult);
+		XMLTest("Move node from within <one> after <two>", xmlAfterTwo, printer4.CStr(), false);
+	}
+
+	{
+		const char* xml = "<svg width = \"128\" height = \"128\">"
+			"	<text> </text>"
+			"</svg>";
+		XMLDocument doc;
+		doc.Parse(xml);
+		XMLTest( "Parse svg with text", false, doc.Error() );
+		doc.Print();
+	}
+
+	{
+		// Test that it doesn't crash.
+		const char* xml = "<?xml version=\"1.0\"?><root><sample><field0><1</field0><field1>2</field1></sample></root>";
+		XMLDocument doc;
+		doc.Parse(xml);
+		XMLTest( "Parse root-sample-field0", true, doc.Error() );
+		doc.PrintError();
+	}
+
+#if 1
+		// the question being explored is what kind of print to use:
+		// https://github.com/leethomason/tinyxml2/issues/63
+	{
+		//const char* xml = "<element attrA='123456789.123456789' attrB='1.001e9' attrC='1.0e-10' attrD='1001000000.000000' attrE='0.1234567890123456789'/>";
+		const char* xml = "<element/>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Parse self-closed empty element", false, doc.Error() );
+		doc.FirstChildElement()->SetAttribute( "attrA-f64", 123456789.123456789 );
+		doc.FirstChildElement()->SetAttribute( "attrB-f64", 1.001e9 );
+		doc.FirstChildElement()->SetAttribute( "attrC-f64", 1.0e9 );
+		doc.FirstChildElement()->SetAttribute( "attrC-f64", 1.0e20 );
+		doc.FirstChildElement()->SetAttribute( "attrD-f64", 1.0e-10 );
+		doc.FirstChildElement()->SetAttribute( "attrD-f64", 0.123456789 );
+
+		doc.FirstChildElement()->SetAttribute( "attrA-f32", 123456789.123456789f );
+		doc.FirstChildElement()->SetAttribute( "attrB-f32", 1.001e9f );
+		doc.FirstChildElement()->SetAttribute( "attrC-f32", 1.0e9f );
+		doc.FirstChildElement()->SetAttribute( "attrC-f32", 1.0e20f );
+		doc.FirstChildElement()->SetAttribute( "attrD-f32", 1.0e-10f );
+		doc.FirstChildElement()->SetAttribute( "attrD-f32", 0.123456789f );
+
+		doc.Print();
+
+		/* The result of this test is platform, compiler, and library version dependent. :("
+		XMLPrinter printer;
+		doc.Print( &printer );
+		XMLTest( "Float and double formatting.",
+			"<element attrA-f64=\"123456789.12345679\" attrB-f64=\"1001000000\" attrC-f64=\"1e+20\" attrD-f64=\"0.123456789\" attrA-f32=\"1.2345679e+08\" attrB-f32=\"1.001e+09\" attrC-f32=\"1e+20\" attrD-f32=\"0.12345679\"/>\n",
+			printer.CStr(),
+			true );
+		*/
+	}
+#endif
+
+    {
+        // Issue #184
+        // If it doesn't assert, it passes. Caused by objects
+        // getting created during parsing which are then
+        // inaccessible in the memory pools.
+        const char* xmlText = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>";
+        {
+            XMLDocument doc;
+            doc.Parse(xmlText);
+            XMLTest( "Parse hex no closing tag round 1", true, doc.Error() );
+        }
+        {
+            XMLDocument doc;
+            doc.Parse(xmlText);
+            XMLTest( "Parse hex no closing tag round 2", true, doc.Error() );
+            doc.Clear();
+        }
+    }
+
+    {
+        // If this doesn't assert in TINYXML2_DEBUG, all is well.
+        tinyxml2::XMLDocument doc;
+        tinyxml2::XMLElement *pRoot = doc.NewElement("Root");
+        doc.DeleteNode(pRoot);
+    }
+
+    {
+        XMLDocument doc;
+        XMLElement* root = doc.NewElement( "Root" );
+        XMLTest( "Node document before insertion", true, &doc == root->GetDocument() );
+        doc.InsertEndChild( root );
+        XMLTest( "Node document after insertion", true, &doc == root->GetDocument() );
+    }
+
+    {
+        // If this doesn't assert in TINYXML2_DEBUG, all is well.
+        XMLDocument doc;
+        XMLElement* unlinkedRoot = doc.NewElement( "Root" );
+        XMLElement* linkedRoot = doc.NewElement( "Root" );
+        doc.InsertFirstChild( linkedRoot );
+        unlinkedRoot->GetDocument()->DeleteNode( linkedRoot );
+        unlinkedRoot->GetDocument()->DeleteNode( unlinkedRoot );
+    }
+
+	{
+		// Should not assert in TINYXML2_DEBUG
+		XMLPrinter printer;
+	}
+
+	{
+		// Issue 291. Should not crash
+		const char* xml = "&#0</a>";
+		XMLDocument doc;
+		doc.Parse( xml );
+		XMLTest( "Parse hex with closing tag", false, doc.Error() );
+
+		XMLPrinter printer;
+		doc.Print( &printer );
+	}
+	{
+		// Issue 299. Can print elements that are not linked in.
+		// Will crash if issue not fixed.
+		XMLDocument doc;
+		XMLElement* newElement = doc.NewElement( "printme" );
+		XMLPrinter printer;
+		bool acceptResult = newElement->Accept( &printer );
+		XMLTest( "printme - Accept()", true, acceptResult );
+		// Delete the node to avoid possible memory leak report in debug output
+		doc.DeleteNode( newElement );
+	}
+	{
+		// Issue 302. Clear errors from LoadFile/SaveFile
+		XMLDocument doc;
+		XMLTest( "Issue 302. Should be no error initially", "XML_SUCCESS", doc.ErrorName() );
+		doc.SaveFile( "./no/such/path/pretty.xml" );
+		XMLTest( "Issue 302. Fail to save", "XML_ERROR_FILE_COULD_NOT_BE_OPENED", doc.ErrorName() );
+		doc.SaveFile( "./resources/out/compact.xml", true );
+		XMLTest( "Issue 302. Subsequent success in saving", "XML_SUCCESS", doc.ErrorName() );
+	}
+
+	{
+		// If a document fails to load then subsequent
+		// successful loads should clear the error
+		XMLDocument doc;
+		XMLTest( "Should be no error initially", false, doc.Error() );
+		doc.LoadFile( "resources/no-such-file.xml" );
+		XMLTest( "No such file - should fail", true, doc.Error() );
+                
+		doc.LoadFile("resources/dream.xml");
+		XMLTest("Error should be cleared", false, doc.Error());
+
+		doc.LoadFile( "resources/xmltest-5330.xml" );
+        XMLTest( "parse errors occur - should fail", true, doc.Error() );
+
+		doc.LoadFile( "resources/dream.xml" );
+		XMLTest( "Error should be cleared", false, doc.Error() );
+	}
+
+	{
+		// Check that declarations are allowed only at beginning of document
+	    const char* xml0 = "<?xml version=\"1.0\" ?>"
+	                       "   <!-- xml version=\"1.1\" -->"
+	                       "<first />";
+	    const char* xml1 = "<?xml version=\"1.0\" ?>"
+	                       "<?xml-stylesheet type=\"text/xsl\" href=\"Anything.xsl\"?>"
+	                       "<first />";
+	    const char* xml2 = "<first />"
+	                       "<?xml version=\"1.0\" ?>";
+	    const char* xml3 = "<first></first>"
+	                       "<?xml version=\"1.0\" ?>";
+
+	    const char* xml4 = "<first><?xml version=\"1.0\" ?></first>";
+
+	    XMLDocument doc;
+	    doc.Parse(xml0);
+	    XMLTest("Test that the code changes do not affect normal parsing", false, doc.Error() );
+	    doc.Parse(xml1);
+	    XMLTest("Test that the second declaration is allowed", false, doc.Error() );
+	    doc.Parse(xml2);
+	    XMLTest("Test that declaration after self-closed child is not allowed", XML_ERROR_PARSING_DECLARATION, doc.ErrorID() );
+	    doc.Parse(xml3);
+	    XMLTest("Test that declaration after a child is not allowed", XML_ERROR_PARSING_DECLARATION, doc.ErrorID() );
+	    doc.Parse(xml4);
+	    XMLTest("Test that declaration inside a child is not allowed", XML_ERROR_PARSING_DECLARATION, doc.ErrorID() );
+	}
+
+    {
+	    // No matter - before or after successfully parsing a text -
+	    // calling XMLDocument::Value() used to cause an assert in debug.
+	    // Null must be returned.
+	    const char* validXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
+	                           "<first />"
+	                           "<second />";
+	    XMLDocument* doc = new XMLDocument();
+	    XMLTest( "XMLDocument::Value() returns null?", NULL, doc->Value() );
+	    doc->Parse( validXml );
+	    XMLTest( "Parse to test XMLDocument::Value()", false, doc->Error());
+	    XMLTest( "XMLDocument::Value() returns null?", NULL, doc->Value() );
+	    delete doc;
+    }
+
+	{
+		XMLDocument doc;
+		for( int i = 0; i < XML_ERROR_COUNT; i++ ) {
+			const XMLError error = static_cast<XMLError>(i);
+			const char* name = XMLDocument::ErrorIDToName(error);
+			XMLTest( "ErrorName() not null after ClearError()", true, name != 0 );
+			if( name == 0 ) {
+				// passing null pointer into strlen() is undefined behavior, so
+				// compiler is allowed to optimise away the null test above if it's
+				// as reachable as the strlen() call
+				continue;
+			}
+			XMLTest( "ErrorName() not empty after ClearError()", true, strlen(name) > 0 );
+		}
+	}
+
+	{
+		const char* html("<!DOCTYPE html><html><body><p>test</p><p><br/></p></body></html>");
+		XMLDocument doc(false);
+		doc.Parse(html);
+
+		XMLPrinter printer(0, true);
+		doc.Print(&printer);
+
+		XMLTest(html, html, printer.CStr());
+	}
+
+	{
+		// Evil memory leaks.
+		// If an XMLElement (etc) is allocated via NewElement() (etc.)
+		// and NOT added to the XMLDocument, what happens?
+		//
+		// Previously (buggy):
+		//		The memory would be free'd when the XMLDocument is
+		//      destructed. But the XMLElement destructor wasn't called, so
+		//      memory allocated for the XMLElement text would not be free'd.
+		//      In practice this meant strings allocated for the XMLElement
+		//      text would be leaked. An edge case, but annoying.
+		// Now:
+		//      The XMLElement destructor is called. But the unlinked nodes
+		//      have to be tracked using a list. This has a minor performance
+		//      impact that can become significant if you have a lot of
+		//      unlinked nodes. (But why would you do that?)
+		// The only way to see this bug was in a Visual C++ runtime debug heap
+		// leak tracker. This is compiled in by default on Windows Debug and
+		// enabled with _CRTDBG_LEAK_CHECK_DF parameter passed to _CrtSetDbgFlag().
+		{
+			XMLDocument doc;
+			doc.NewElement("LEAK 1");
+		}
+		{
+			XMLDocument doc;
+			XMLElement* ele = doc.NewElement("LEAK 2");
+			doc.DeleteNode(ele);
+		}
+	}
+
+	{
+		// Bad bad crash. Parsing error results in stack overflow, if uncaught.
+		const char* TESTS[] = {
+			"./resources/xmltest-5330.xml",
+			"./resources/xmltest-4636783552757760.xml",
+			"./resources/xmltest-5720541257269248.xml",
+			0
+		};
+		for (int i=0; TESTS[i]; ++i) {
+			XMLDocument doc;
+			doc.LoadFile(TESTS[i]);
+			XMLTest("Stack overflow prevented.", XML_ELEMENT_DEPTH_EXCEEDED, doc.ErrorID());
+		}
+	}
+    {
+        const char* TESTS[] = {
+            "./resources/xmltest-5662204197076992.xml",     // Security-level performance issue.
+            0
+        };
+        for (int i = 0; TESTS[i]; ++i) {
+            XMLDocument doc;
+            doc.LoadFile(TESTS[i]);
+            // Need only not crash / lock up.
+            XMLTest("Fuzz attack prevented.", true, true);
+        }
+    }
+	{
+		// Crashing reported via email.
+		const char* xml =
+			"<playlist id='playlist1'>"
+			"<property name='track_name'>voice</property>"
+			"<property name='audio_track'>1</property>"
+			"<entry out = '604' producer = '4_playlist1' in = '0' />"
+			"<blank length = '1' />"
+			"<entry out = '1625' producer = '3_playlist' in = '0' />"
+			"<blank length = '2' />"
+			"<entry out = '946' producer = '2_playlist1' in = '0' />"
+			"<blank length = '1' />"
+			"<entry out = '128' producer = '1_playlist1' in = '0' />"
+			"</playlist>";
+
+		// It's not a good idea to delete elements as you walk the
+		// list. I'm not sure this technically should work; but it's
+		// an interesting test case.
+		XMLDocument doc;
+		XMLError err = doc.Parse(xml);
+		XMLTest("Crash bug parsing", XML_SUCCESS, err );
+
+		XMLElement* playlist = doc.FirstChildElement("playlist");
+		XMLTest("Crash bug parsing", true, playlist != 0);
+
+		{
+			const char* elementName = "entry";
+			XMLElement* entry = playlist->FirstChildElement(elementName);
+			XMLTest("Crash bug parsing", true, entry != 0);
+			while (entry) {
+				XMLElement* todelete = entry;
+				entry = entry->NextSiblingElement(elementName);
+				playlist->DeleteChild(todelete);
+			}
+			entry = playlist->FirstChildElement(elementName);
+			XMLTest("Crash bug parsing", true, entry == 0);
+		}
+		{
+			const char* elementName = "blank";
+			XMLElement* blank = playlist->FirstChildElement(elementName);
+			XMLTest("Crash bug parsing", true, blank != 0);
+			while (blank) {
+				XMLElement* todelete = blank;
+				blank = blank->NextSiblingElement(elementName);
+				playlist->DeleteChild(todelete);
+			}
+			XMLTest("Crash bug parsing", true, blank == 0);
+		}
+
+		tinyxml2::XMLPrinter printer;
+		const bool acceptResult = playlist->Accept(&printer);
+		XMLTest("Crash bug parsing - Accept()", true, acceptResult);
+		printf("%s\n", printer.CStr());
+
+		// No test; it only need to not crash.
+		// Still, wrap it up with a sanity check
+		int nProperty = 0;
+		for (const XMLElement* p = playlist->FirstChildElement("property"); p; p = p->NextSiblingElement("property")) {
+			nProperty++;
+		}
+		XMLTest("Crash bug parsing", 2, nProperty);
+	}
+
+    // ----------- Line Number Tracking --------------
+    {
+        struct TestUtil: XMLVisitor
+        {
+            TestUtil() : str() {}
+
+            void TestParseError(const char *testString, const char *docStr, XMLError expected_error, int expectedLine)
+            {
+                XMLDocument doc;
+                const XMLError parseError = doc.Parse(docStr);
+
+                XMLTest(testString, parseError, doc.ErrorID());
+                XMLTest(testString, true, doc.Error());
+                XMLTest(testString, expected_error, parseError);
+                XMLTest(testString, expectedLine, doc.ErrorLineNum());
+            };
+
+            void TestStringLines(const char *testString, const char *docStr, const char *expectedLines)
+            {
+                XMLDocument doc;
+                doc.Parse(docStr);
+                XMLTest(testString, false, doc.Error());
+                TestDocLines(testString, doc, expectedLines);
+            }
+
+            void TestFileLines(const char *testString, const char *file_name, const char *expectedLines)
+            {
+                XMLDocument doc;
+                doc.LoadFile(file_name);
+                XMLTest(testString, false, doc.Error());
+                TestDocLines(testString, doc, expectedLines);
+            }
+
+        private:
+            DynArray<char, 10> str;
+
+            void Push(char type, int lineNum)
+            {
+                str.Push(type);
+                str.Push(char('0' + (lineNum / 10)));
+                str.Push(char('0' + (lineNum % 10)));
+            }
+
+            bool VisitEnter(const XMLDocument& doc)
+            {
+                Push('D', doc.GetLineNum());
+                return true;
+            }
+            bool VisitEnter(const XMLElement& element, const XMLAttribute* firstAttribute)
+            {
+                Push('E', element.GetLineNum());
+                for (const XMLAttribute *attr = firstAttribute; attr != 0; attr = attr->Next())
+                    Push('A', attr->GetLineNum());
+                return true;
+            }
+            bool Visit(const XMLDeclaration& declaration)
+            {
+                Push('L', declaration.GetLineNum());
+                return true;
+            }
+            bool Visit(const XMLText& text)
+            {
+                Push('T', text.GetLineNum());
+                return true;
+            }
+            bool Visit(const XMLComment& comment)
+            {
+                Push('C', comment.GetLineNum());
+                return true;
+            }
+            bool Visit(const XMLUnknown& unknown)
+            {
+                Push('U', unknown.GetLineNum());
+                return true;
+            }
+
+            void TestDocLines(const char *testString, XMLDocument &doc, const char *expectedLines)
+            {
+                str.Clear();
+                const bool acceptResult = doc.Accept(this);
+                XMLTest(testString, true, acceptResult);
+                str.Push(0);
+                XMLTest(testString, expectedLines, str.Mem());
+            }
+        } tester;
+
+		tester.TestParseError("ErrorLine-Parsing", "\n<root>\n foo \n<unclosed/>", XML_ERROR_PARSING, 2);
+        tester.TestParseError("ErrorLine-Declaration", "<root>\n<?xml version=\"1.0\"?>", XML_ERROR_PARSING_DECLARATION, 2);
+        tester.TestParseError("ErrorLine-Mismatch", "\n<root>\n</mismatch>", XML_ERROR_MISMATCHED_ELEMENT, 2);
+        tester.TestParseError("ErrorLine-CData", "\n<root><![CDATA[ \n foo bar \n", XML_ERROR_PARSING_CDATA, 2);
+        tester.TestParseError("ErrorLine-Text", "\n<root>\n foo bar \n", XML_ERROR_PARSING_TEXT, 3);
+        tester.TestParseError("ErrorLine-Comment", "\n<root>\n<!-- >\n", XML_ERROR_PARSING_COMMENT, 3);
+        tester.TestParseError("ErrorLine-Declaration", "\n<root>\n<? >\n", XML_ERROR_PARSING_DECLARATION, 3);
+        tester.TestParseError("ErrorLine-Unknown", "\n<root>\n<! \n", XML_ERROR_PARSING_UNKNOWN, 3);
+        tester.TestParseError("ErrorLine-Element", "\n<root>\n<unclosed \n", XML_ERROR_PARSING_ELEMENT, 3);
+        tester.TestParseError("ErrorLine-Attribute", "\n<root>\n<unclosed \n att\n", XML_ERROR_PARSING_ATTRIBUTE, 4);
+        tester.TestParseError("ErrorLine-ElementClose", "\n<root>\n<unclosed \n/unexpected", XML_ERROR_PARSING_ELEMENT, 3);
+
+		tester.TestStringLines(
+            "LineNumbers-String",
+
+            "<?xml version=\"1.0\"?>\n"					// 1 Doc, DecL
+                "<root a='b' \n"						// 2 Element Attribute
+                "c='d'> d <blah/>  \n"					// 3 Attribute Text Element
+                "newline in text \n"					// 4 Text
+                "and second <zxcv/><![CDATA[\n"			// 5 Element Text
+                " cdata test ]]><!-- comment -->\n"		// 6 Comment
+                "<! unknown></root>",					// 7 Unknown
+
+            "D01L01E02A02A03T03E03T04E05T05C06U07");
+
+		tester.TestStringLines(
+            "LineNumbers-CRLF",
+
+            "\r\n"										// 1 Doc (arguably should be line 2)
+            "<?xml version=\"1.0\"?>\n"					// 2 DecL
+            "<root>\r\n"								// 3 Element
+            "\n"										// 4
+            "text containing new line \n"				// 5 Text
+            " and also containing crlf \r\n"			// 6
+            "<sub><![CDATA[\n"							// 7 Element Text
+            "cdata containing new line \n"				// 8
+            " and also containing cflr\r\n"				// 9
+            "]]></sub><sub2/></root>",					// 10 Element
+
+            "D01L02E03T05E07T07E10");
+
+		tester.TestFileLines(
+            "LineNumbers-File",
+            "resources/utf8test.xml",
+            "D01L01E02E03A03A03T03E04A04A04T04E05A05A05T05E06A06A06T06E07A07A07T07E08A08A08T08E09T09E10T10");
+    }
+
+    {
+    	const char* xml = "<Hello>Text</Error>";
+    	XMLDocument doc;
+    	doc.Parse(xml);
+    	XMLTest("Test mismatched elements.", true, doc.Error());
+    	XMLTest("Test mismatched elements.", XML_ERROR_MISMATCHED_ELEMENT, doc.ErrorID());
+    	// For now just make sure calls work & doesn't crash.
+    	// May solidify the error output in the future.
+    	printf("%s\n", doc.ErrorStr());
+    	doc.PrintError();
+    }
+
+	// ---------- CVE-2024-50615 -----------
+	{
+		const char* xml = "<Hello value='12&#65;34' value2='56&#x42;78'>Text</Hello>";
+		XMLDocument doc;
+		doc.Parse(xml);
+		const char* value = doc.FirstChildElement()->Attribute("value");
+		const char* value2 = doc.FirstChildElement()->Attribute("value2");
+		XMLTest("Test attribute encode", false, doc.Error());
+		XMLTest("Test decimal value", value, "12A34");
+		XMLTest("Test hex encode", value2, "56B78");
+	}
+
+	{
+		const char* xml = "<Hello value='&#ABC9000000065;' value2='&#xffffffff;' value3='&#5000000000;' value4='&#x00000045;' value5='&#x000000000000000021;'>Text</Hello>";
+		XMLDocument doc;
+		doc.Parse(xml);
+		const char* value = doc.FirstChildElement()->Attribute("value");
+		const char* value2 = doc.FirstChildElement()->Attribute("value2");
+		const char* value3 = doc.FirstChildElement()->Attribute("value3");
+		const char* value4 = doc.FirstChildElement()->Attribute("value4");
+		const char* value5 = doc.FirstChildElement()->Attribute("value5");
+		XMLTest("Test attribute encode", false, doc.Error());
+		XMLTest("Test attribute encode too long value", value, "&#ABC9000000065;"); // test long value
+		XMLTest("Test attribute encode out of unicode range", value2, "&#xffffffff;"); // out of unicode range
+		XMLTest("Test attribute encode out of int max value", value3, "&#5000000000;"); // out of int max value
+		XMLTest("Test attribute encode with a Hex value", value4, "E"); // hex value in unicode value
+		XMLTest("Test attribute encode with a Hex value", value5, "!"); // hex value in unicode value
+	}
+
+    // ----------- Performance tracking --------------
+	{
+#if defined( _MSC_VER )
+		__int64 start, end, freq;
+		QueryPerformanceFrequency((LARGE_INTEGER*)&freq);
+#endif
+
+		FILE* perfFP = fopen("resources/dream.xml", "r");
+		XMLTest("Open dream.xml", true, perfFP != 0);
+		fseek(perfFP, 0, SEEK_END);
+		long size = ftell(perfFP);
+		fseek(perfFP, 0, SEEK_SET);
+
+		char* mem = new char[size + 1];
+		memset(mem, 0xfe, size);
+		size_t bytesRead = fread(mem, 1, size, perfFP);
+		XMLTest("Read dream.xml", true, uint32_t(size) >= uint32_t(bytesRead));
+		fclose(perfFP);
+		mem[size] = 0;
+
+#if defined( _MSC_VER )
+		QueryPerformanceCounter((LARGE_INTEGER*)&start);
+#else
+		clock_t cstart = clock();
+#endif
+		bool parseDreamXmlFailed = false;
+		static const int COUNT = 10;
+		for (int i = 0; i < COUNT; ++i) {
+			XMLDocument doc;
+			doc.Parse(mem);
+			parseDreamXmlFailed = parseDreamXmlFailed || doc.Error();
+		}
+#if defined( _MSC_VER )
+		QueryPerformanceCounter((LARGE_INTEGER*)&end);
+#else
+		clock_t cend = clock();
+#endif
+		XMLTest( "Parse dream.xml", false, parseDreamXmlFailed );
+
+		delete[] mem;
+
+		static const char* note =
+#ifdef TINYXML2_DEBUG
+			"DEBUG";
+#else
+			"Release";
+#endif
+
+#if defined( _MSC_VER )
+		const double duration = 1000.0 * (double)(end - start) / ((double)freq * (double)COUNT);
+#else
+		const double duration = (double)(cend - cstart) / (double)COUNT;
+#endif
+		printf("\nParsing dream.xml (%s): %.3f milli-seconds\n", note, duration);
+	}
+
+#if defined( _MSC_VER ) &&  defined( TINYXML2_DEBUG )
+	{
+		_CrtMemCheckpoint( &endMemState );
+
+		_CrtMemState diffMemState;
+		_CrtMemDifference( &diffMemState, &startMemState, &endMemState );
+		_CrtMemDumpStatistics( &diffMemState );
+
+		{
+			int leaksBeforeExit = _CrtDumpMemoryLeaks();
+			XMLTest( "No leaks before exit?", FALSE, leaksBeforeExit );
+		}
+	}
+#endif
+
+	printf ("\nPass %d, Fail %d\n", gPass, gFail);
+
+	return gFail;
+}


### PR DESCRIPTION
- [x] Combined "tinyxml2.cpp" and "tinyxml2.h" into "tinyxml2.hpp" which is a header only file for easier integration into ROS projects. Merging is done by copying the content directly and merging the namespaces. Changes are kept minimum (more optimizations can be done but not performed) due to easier future maintenance.
- [x] Updated and formatted the Makefile to include additional test "xmltest2.cpp" that testes the new header file
- [x] Updated CMakeLists.txt to include additional test "xmltest2.cpp"
- [x] Updated ReadMe.md to include info about new file
- [x] Updated workflow by removing ubuntu 20.04 because github have removed the runners 
- [x] Updated workflow by adding ubuntu 22.04 and 24.04 because github have added the runners 
- [x] Verified new file passes all the tests (makefile based, cmakelists.txt based and gitworkflow based) 