### PR TITLE
Replace library functions(isalpha & isspace)

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -572,16 +572,14 @@ public:
         if ( ch > 32 ) {
             return false;
         }
-        return ( mask >> ( ch & 63 ) ) & 1;
+        return mask >> ch & 1;
     }
 
-    // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
-    // correct, but simple, and usually works.
     static bool IsWhiteSpace( char p )					{
-        return !IsUTF8Continuation(p) && IsSpace( static_cast<unsigned char>(p) );
+        return IsSpace( static_cast<unsigned char>(p) );
     }
 
-    // The method checks the char for matching ':', '_', alphabetic symbols and char >= 128 by bit mask 
+    // The method checks a char for matching ':', '_', alphabetic symbols or char >= 128 by bit mask 
     inline static bool IsNameStartChar( unsigned char ch ) {
         static constexpr uint64_t mask[4] = { 1ULL << 58 , 1ULL << 31 | 0x07FFFFFE07FFFFFE , ~0ULL, ~0ULL};
         return ( mask[ch >> 6] >> ( ch & 63 ) ) & 1;

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -561,22 +561,30 @@ public:
     static char* SkipWhiteSpace( char* const p, int* curLineNumPtr ) {
         return const_cast<char*>( SkipWhiteSpace( const_cast<const char*>(p), curLineNumPtr ) );
     }
+    inline static bool IsSpace( unsigned char ch ) {
+        static constexpr uint64_t mask =
+                  1ULL << 9
+                | 1ULL << 10
+                | 1ULL << 11
+                | 1ULL << 12
+                | 1ULL << 13
+                | 1ULL << 32;
+        if ( ch > 32 ) {
+            return false;
+        }
+        return ( mask >> ( ch & 63 ) ) & 1;
+    }
 
     // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
     // correct, but simple, and usually works.
     static bool IsWhiteSpace( char p )					{
-        return !IsUTF8Continuation(p) && isspace( static_cast<unsigned char>(p) );
+        return !IsUTF8Continuation(p) && IsSpace( static_cast<unsigned char>(p) );
     }
 
+    // The method checks the char for matching ':', '_', alphabetic symbols and char >= 128 by bit mask 
     inline static bool IsNameStartChar( unsigned char ch ) {
-        if ( ch >= 128 ) {
-            // This is a heuristic guess in attempt to not implement Unicode-aware isalpha()
-            return true;
-        }
-        if ( isalpha( ch ) ) {
-            return true;
-        }
-        return ch == ':' || ch == '_';
+        static constexpr uint64_t mask[4] = { 1ULL << 58 , 1ULL << 31 | 0x07FFFFFE07FFFFFE , ~0ULL, ~0ULL};
+        return ( mask[ch >> 6] >> ( ch & 63 ) ) & 1;
     }
 
     inline static bool IsNameChar( unsigned char ch ) {

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -2729,6 +2729,26 @@ int main( int argc, const char ** argv )
 			}
 		}
 	}
+
+        // ---------- Testing IsNameStartChar ----------
+    {
+
+        XMLUtil test;
+        XMLTest("IsNameStartChar(':')", true, test.IsNameStartChar(':'));
+        XMLTest("IsNameStartChar('_')", true, test.IsNameStartChar('_'));
+        XMLTest("IsNameStartChar('@')", false, test.IsNameStartChar('@'));
+        XMLTest("IsNameStartChar('A')", true, test.IsNameStartChar('A'));
+        XMLTest("IsNameStartChar('Z')", true, test.IsNameStartChar('Z'));
+        XMLTest("IsNameStartChar('[')", false, test.IsNameStartChar('['));
+        XMLTest("IsNameStartChar('`')", false, test.IsNameStartChar('`'));
+        XMLTest("IsNameStartChar('a')", true, test.IsNameStartChar('a'));
+        XMLTest("IsNameStartChar('z')", true, test.IsNameStartChar('z'));
+        XMLTest("IsNameStartChar('{')", false, test.IsNameStartChar('{'));
+        XMLTest("IsNameStartChar(127)", false, test.IsNameStartChar(static_cast<unsigned char>(127)));
+        XMLTest("IsNameStartChar(128)", true, test.IsNameStartChar(static_cast<unsigned char>(128)));
+        XMLTest("IsNameStartChar(255)", true, test.IsNameStartChar(static_cast<unsigned char>(255)));
+    }
+
 	
     // ----------- Performance tracking --------------
 	{

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -2732,8 +2732,8 @@ int main( int argc, const char ** argv )
 
         // ---------- Testing IsNameStartChar ----------
     {
-
         XMLUtil test;
+        // Tests validate key edge cases for IsNameStartChar without exhaustive coverage 
         XMLTest("IsNameStartChar(':')", true, test.IsNameStartChar(':'));
         XMLTest("IsNameStartChar('_')", true, test.IsNameStartChar('_'));
         XMLTest("IsNameStartChar('@')", false, test.IsNameStartChar('@'));


### PR DESCRIPTION
Add new method IsAlpha and rewrite IsNameStartChar to avoid using library functions. Since the old functions were applied only to us-ASCII characters, bit mask can be used in rewritten methods. It gives a good acceleration: 11-15% x86, about 20% RISCV.