### PR TITLE
Improved XMLNode::~XMLNode perfomance

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -810,7 +810,14 @@ XMLNode::XMLNode( XMLDocument* doc ) :
 
 XMLNode::~XMLNode()
 {
-    DeleteChildren();
+    XMLNode *currentChild = _firstChild;
+    while (currentChild != NULL) {
+        XMLNode *next = currentChild->_next;
+        currentChild->_parent = 0;
+        DeleteNode(currentChild);
+        currentChild = next;
+    }
+
     if ( _parent ) {
         _parent->Unlink( this );
     }


### PR DESCRIPTION
XMLNode::~XMLNode uses interface method DeleteChildren(), which iteratively removes the first child until the list is empty. Each single removal performs additional checks and keeps _firstChild and _lastChild links in a consistent state. This leads to a performance penalty.

The proposed patch solves this problem by iterating the list of the children and directly destroying them without keeping links in a consistent state.

The performance boost we gained on xmltest is:
- 3% for my laptop (x86_64)
- 9% for bananapi f3 board (riscv64)