### PR TITLE
Fix GCC 4.9.3 Build Errors

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -446,17 +446,17 @@ void XMLUtil::ConvertUTF32ToUTF8( unsigned long input, char* output, int* length
             --output;
             *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
-            //fall through
+            TIXML_FALLTHROUGH;
         case 3:
             --output;
             *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
-            //fall through
+            TIXML_FALLTHROUGH;
         case 2:
             --output;
             *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
             input >>= 6;
-            //fall through
+            TIXML_FALLTHROUGH;
         case 1:
             --output;
             *output = static_cast<char>(input | FIRST_BYTE_MARK[*length]);

--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -93,6 +93,43 @@ distribution.
 #endif
 #endif
 
+#ifndef __has_attribute
+#   define __has_attribute(x) 0
+#endif
+#ifdef __cplusplus
+#   ifndef __has_cpp_attribute
+#      define __has_cpp_attribute(x) 0
+#   endif
+#else
+#   ifndef __has_c_attribute
+#      define __has_c_attribute(x) 0
+#   endif
+#endif
+
+#ifdef __cplusplus
+#   if defined(_MSC_VER)
+#      define TIXML_FALLTHROUGH (void(0))
+#   elif (__cplusplus >= 201703L && __has_cpp_attribute(fallthrough))
+#      define TIXML_FALLTHROUGH [[fallthrough]]
+#   elif __has_cpp_attribute(clang::fallthrough)
+#      define TIXML_FALLTHROUGH [[clang::fallthrough]]
+#   elif __has_attribute(fallthrough)
+#      define TIXML_FALLTHROUGH __attribute__((fallthrough))
+#   else
+#      define TIXML_FALLTHROUGH (void(0))
+#   endif
+#else
+#   if defined(_MSC_VER)
+#      define TIXML_FALLTHROUGH (void(0))
+#   elif __has_c_attribute(fallthrough)
+#      define TIXML_FALLTHROUGH [[fallthrough]]
+#   elif __has_attribute(fallthrough)
+#      define TIXML_FALLTHROUGH __attribute__((fallthrough))
+#   else
+#      define TIXML_FALLTHROUGH (void(0))
+#   endif
+#endif
+
 /* Versioning, past 1.0.14:
 	http://semver.org/
 */


### PR DESCRIPTION
Since GCC version 4.9.3 does not support the -Wimplicit-fallthrough warning option or the __attribute__((fallthrough)) annotation, introduce the corresponding fixes to prevent build errors.