### PR TITLE
Mark project constants depending on C++ version

### DIFF
--- a/tinyxml2.h
+++ b/tinyxml2.h
@@ -93,12 +93,20 @@ distribution.
 #endif
 #endif
 
+#if defined(__cplusplus) && __cplusplus >= 201703L
+#define TINYXML2_CONSTANT inline constexpr
+#elif defined(__cplusplus) && __cplusplus >= 201103L
+#define TINYXML2_CONSTANT static constexpr
+#else 
+#define TINYXML2_CONSTANT static const
+#endif
+
 /* Versioning, past 1.0.14:
 	http://semver.org/
 */
-static const int TIXML2_MAJOR_VERSION = 11;
-static const int TIXML2_MINOR_VERSION = 0;
-static const int TIXML2_PATCH_VERSION = 0;
+TINYXML2_CONSTANT int TIXML2_MAJOR_VERSION = 11;
+TINYXML2_CONSTANT int TIXML2_MINOR_VERSION = 0;
+TINYXML2_CONSTANT int TIXML2_PATCH_VERSION = 0;
 
 #define TINYXML2_MAJOR_VERSION 11
 #define TINYXML2_MINOR_VERSION 0
@@ -109,7 +117,7 @@ static const int TIXML2_PATCH_VERSION = 0;
 // system, and the capacity of the stack. On the other hand, it's a trivial
 // attack that can result from ill, malicious, or even correctly formed XML,
 // so there needs to be a limit in place.
-static const int TINYXML2_MAX_ELEMENT_DEPTH = 500;
+TINYXML2_CONSTANT int TINYXML2_MAX_ELEMENT_DEPTH = 500;
 
 namespace tinyxml2
 {


### PR DESCRIPTION
This PR is another part of #1051, which marks important library information constants such as `TIXML2_MAJOR_VERSION`, `TINYXML2_MAX_ELEMENT_DEPTH`, etc. as `constexpr` if in C++11 or later, otherwise just `static const` as before.

This is a necessary first step as part of the modules proposal, as modules cannot directly export macros (as preprocessor macros are evaluated at preprocessing time, and modules can only export symbols). Furthermore, for a constant to be exportable, it must have external linkage (which is made possible with `inline constexpr`). For that reason it is a separate PR from the actual modules feature PR.