### PR TITLE
Fix issue #1048: Add null pointer check in XMLDocument::DeleteNode

### DIFF
--- a/tinyxml2.cpp
+++ b/tinyxml2.cpp
@@ -2344,9 +2344,12 @@ static FILE* callfopen( const char* filepath, const char* mode )
     return fp;
 }
 
-void XMLDocument::DeleteNode( XMLNode* node )	{
+void XMLDocument::DeleteNode( XMLNode* node )	{   
     TIXMLASSERT( node );
     TIXMLASSERT(node->_document == this );
+    if(node == 0) {
+        return; // check for null pointer
+    }
     if (node->_parent) {
         node->_parent->DeleteChild( node );
     }

--- a/xmltest.cpp
+++ b/xmltest.cpp
@@ -2025,7 +2025,13 @@ int main( int argc, const char ** argv )
 		XMLTest("Parse nested elements with pedantic whitespace", false, doc.Error());
 		XMLTest("Pedantic whitespace", true, 0 == doc.RootElement()->FirstChildElement()->GetText());
 	}
-
+	//Check the robustness of the DeleteNode function in handling null pointers.
+	{
+		XMLDocument doc;
+		doc.DeleteNode(nullptr);
+		XMLTest("DeleteNode with null pointer", true, doc.Error() == XML_SUCCESS);
+	}
+		
 	// Check sample xml can be parsed with pedantic mode
 	{
 		XMLDocument doc(true, PEDANTIC_WHITESPACE);


### PR DESCRIPTION
- Add null pointer check in XMLDocument::DeleteNode() method
- Add test case to verify null pointer handling
- Prevents segmentation fault when calling DeleteNode(nullptr)